### PR TITLE
feat: 회원탈퇴 로직 구현

### DIFF
--- a/src/config/passport.ts
+++ b/src/config/passport.ts
@@ -1,11 +1,9 @@
 import passport from 'passport';
 import { Strategy as JwtStrategy, ExtractJwt, StrategyOptionsWithRequest, VerifiedCallback } from 'passport-jwt';
-import { PrismaClient } from '@prisma/client';
 import { Request } from 'express';
 import { configureGoogleStrategy } from './social/google';
 import { configureNaverStrategy } from './social/naver';
-
-const prisma = new PrismaClient();
+import prisma from './prisma';
 
 // JWT Strategy 설정
 const options: StrategyOptionsWithRequest = {

--- a/src/config/prisma.ts
+++ b/src/config/prisma.ts
@@ -1,3 +1,5 @@
 import { PrismaClient } from '@prisma/client';
 
-export const prisma = new PrismaClient();
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import passport from './config/passport';
 import swaggerUi from 'swagger-ui-express';
 import session from 'express-session';
 import authRouter from './routes/auth';
+import membersRouter from './members/routes/member.route'; // members 라우터 import
 import promptRoutes from './prompts/prompt.route';
 import promptReviewRouter from './reviews/routes/prompt-review.route';
 // import * as swaggerDocument from './docs/swagger/swagger.json'; 
@@ -31,6 +32,9 @@ app.use(passport.session());
 
 // 인증 라우터
 app.use('/auth', authRouter);
+
+// 회원 라우터
+app.use('/api/members', membersRouter);
 
 // 프롬프트 리뷰 라우터
 app.use('/api/prompts/:promptId/reviews', promptReviewRouter);

--- a/src/members/controllers/member.controller.ts
+++ b/src/members/controllers/member.controller.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from 'express';
+import MemberService from '../services/member.service';
+
+class MemberController {
+  async withdraw(req: Request, res: Response): Promise<void> {
+    try {
+      const user = req.user as any;
+      await MemberService.withdrawUser(user.user_id);
+      res.status(200).json({ message: '회원 탈퇴가 성공적으로 처리되었습니다.' });
+    } catch (error) {
+      console.error('Withdrawal error:', error);
+      res.status(500).json({ message: '회원 탈퇴 처리 중 오류가 발생했습니다.' });
+    }
+  }
+}
+
+export default new MemberController(); 

--- a/src/members/repositories/member.repository.ts
+++ b/src/members/repositories/member.repository.ts
@@ -1,0 +1,15 @@
+import prisma from '../../config/prisma';
+
+class MemberRepository {
+  async softDeleteUser(userId: number): Promise<void> {
+    await prisma.user.update({
+      where: { user_id: userId },
+      data: {
+        status: false,
+        inactive_date: new Date(),
+      },
+    });
+  }
+}
+
+export default new MemberRepository(); 

--- a/src/members/routes/member.route.ts
+++ b/src/members/routes/member.route.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { authenticateJwt } from '../../config/passport';
+import MemberController from '../controllers/member.controller';
+
+const router = Router();
+
+// 회원 탈퇴
+router.delete('/withdrawal', authenticateJwt, MemberController.withdraw);
+
+export default router; 

--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -1,0 +1,9 @@
+import MemberRepository from '../repositories/member.repository';
+
+class MemberService {
+  async withdrawUser(userId: number): Promise<void> {
+    await MemberRepository.softDeleteUser(userId);
+  }
+}
+
+export default new MemberService(); 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,10 +1,10 @@
 import { Router, Request, Response } from 'express';
-import { PrismaClient } from '@prisma/client';
 import googleAuthRouter from './auth/google';
 import naverAuthRouter from './auth/naver';
+import prisma from '../config/prisma';
+import { authenticateJwt } from '../config/passport';
 
 const router = Router();
-const prisma = new PrismaClient();
 
 // 소셜 로그인 라우터
 router.use('/google', googleAuthRouter);


### PR DESCRIPTION
## 📌 기능 설명
회원 탈퇴 로직 구현 (Soft Delete)

## 📌 구현 내용
Soft Delete 방식으로 회원 탈퇴 구현
API 요청 시 회원의 status가 1에서 0으로, inactive_date가 생성
src/config/prisma.ts를 통해서 프로젝트 전역에서 사용할 단일 PrismaClient 인스턴스 생성

## 📌 구현 결과
<img width="970" height="474" alt="image" src="https://github.com/user-attachments/assets/b7757020-5017-45ae-bcd9-e38bcfcd81cf" />
<img width="674" height="77" alt="image" src="https://github.com/user-attachments/assets/225875f6-b59f-446f-aedd-c93a4e3d10a0" />


## 📌 논의하고 싶은 점
inactive_date로 부터 얼마나 지나야 데이터베이스에서 완전히 삭제할지 논의해야합니다