### PR TITLE
bug: 소셜 로그인 500에러

### DIFF
--- a/prisma/migrations/20250721065406_add_unique_constraint_to_user_email/migration.sql
+++ b/prisma/migrations/20250721065406_add_unique_constraint_to_user_email/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[email]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE `User` MODIFY `name` VARCHAR(50) NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `User_email_key` ON `User`(`email`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,9 +26,9 @@ enum Role {
 
 model User {
   user_id       Int       @id @default(autoincrement())
-  name          String    @db.VarChar(10)
+  name          String    @db.VarChar(50)
   nickname      String    @db.VarChar(50)
-  email         String    @db.VarChar(255)
+  email         String    @unique @db.VarChar(255)
   social_type   String    @db.VarChar(50)
   status        Boolean
   inactive_date DateTime?


### PR DESCRIPTION
## 📌 기능 설명
사용자가 소셜 로그인(Google, Naver)으로 처음 회원가입을 시도할 때, 간헐적으로 500 Internal Server Error가 발생하며 실패하는 버그를 수정했습니다. 이 PR은 회원가입 프로세스의 안정성을 확보하여 사용자 경험을 개선하는 것을 목표로 합니다.

## 📌 구현 내용

### 1. **원인 분석: 회원가입 시의 경합 상태 (Race Condition)**
-   기존 로직은 DB에서 사용자를 조회(`findFirst`)하고, 없을 경우 새로운 사용자를 생성(`create`)하는 두 단계로 나누어져 있었습니다.
-   네트워크 지연 등으로 로그인 콜백 요청이 거의 동시에 두 번 이상 서버에 도달할 경우, 각 요청이 모두 사용자가 없다고 판단하여 `create`를 시도했습니다.
-   이로 인해 두 번째 `create` 요청이 데이터베이스의 `UNIQUE` 제약 조건(email)에 위배되어 실패하면서, 사용자에게는 500 에러가 표시되는 문제가 있었습니다.

### 2. **데이터베이스 스키마 수정 (`@unique` 추가)**
-   `prisma/schema.prisma` 파일의 `User` 모델에서 `email` 필드에 `@unique` 제약 조건을 명시적으로 추가했습니다.
-   이는 데이터 무결성을 강화하고, 이어지는 `upsert` 로직을 보다 안전하고 효율적으로 사용하기 위한 필수적인 작업입니다.
-   `prisma migrate`를 통해 해당 변경사항을 데이터베이스에 성공적으로 적용했습니다.

### 3. **로그인 로직 개선 (`upsert` 도입)**
-   Google(`google.ts`) 및 Naver(`naver.ts`) 로그인 전략 파일에서, 기존의 `findFirst`와 `create`로 분리되어 있던 로직을 Prisma의 원자적(atomic) 연산인 **`upsert`** 로 통합했습니다.
-   `upsert`는 "사용자가 있으면 업데이트하고, 없으면 생성하는" 과정을 단일 트랜잭션으로 처리하므로, 경합 상태 문제를 원천적으로 해결합니다.

### 4. **환경 변수 관리 개선**
-   이전 작업에서 임시로 하드코딩 되어있던 소셜 로그인 `callbackURL`을 다시 `.env` 파일의 `GOOGLE_CALLBACK_URL`과 `NAVER_CALLBACK_URL`을 사용하도록 되돌렸습니다.

## 📌 구현 결과
이번 작업은 백엔드 로직 수정이므로 별도의 UI 변경 사항은 없습니다. 

## 📌 논의하고 싶은 점

