### PR TITLE
Feat/#9

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import authRouter from './auth/routes/auth.route'; // auth 라우터 경로 수�
 import membersRouter from './members/routes/member.route'; // members 라우터 import
 import promptRoutes from './prompts/prompt.route';
 import promptReviewRouter from './reviews/routes/prompt-review.route';
+import promptDownloadRouter from './prompts/routes/prompt.downlaod.route'
 import promptLikeRouter from './prompts/routes/prompt.like.route';
 // import * as swaggerDocument from './docs/swagger/swagger.json'; 
 // import { RegisterRoutes } from './routes/routes'; // tsoa가 생성하는 파일
@@ -50,6 +51,10 @@ const PORT = 3000;
 // 프롬프트 관련 라우터
   // 프롬프트 검색 API
 app.use('/api/prompts', promptRoutes);
+
+  // 프롬프트 무료 다운로드 라우터
+app.use('/api/prompts', promptDownloadRouter);
+
   // 프롬프트 찜 라우터
 app.use('/api/prompts', promptLikeRouter);
 

--- a/src/prompts/routes/prompt.downlaod.route.ts
+++ b/src/prompts/routes/prompt.downlaod.route.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
+import { authenticateJwt } from '../../config/passport';
 import { PromptDownloadController } from '../controllers/prompt.download.controller';
 
 const router = Router();
 
-router.get('/:promptId/downloads', PromptDownloadController.getPromptContent);
+router.get('/:promptId/downloads', authenticateJwt, PromptDownloadController.getPromptContent);
 
 export default router;

--- a/src/prompts/routes/prompt.downlaod.route.ts
+++ b/src/prompts/routes/prompt.downlaod.route.ts
@@ -3,6 +3,6 @@ import { PromptDownloadController } from '../controllers/prompt.download.control
 
 const router = Router();
 
-router.get('/prompts/:promptId/downloads', PromptDownloadController.getPromptContent);
+router.get('/:promptId/downloads', PromptDownloadController.getPromptContent);
 
 export default router;

--- a/src/prompts/services/prompt.download.service.ts
+++ b/src/prompts/services/prompt.download.service.ts
@@ -13,6 +13,15 @@ export const PromptDownloadService = {
       };
     }
 
+    // 유료 프롬프트인 경우 다운로드 불가 처리
+    if (!prompt.is_free) {
+      throw {
+        statusCode: 403,
+        error: 'Forbidden',
+        message: '해당 프롬프트는 무료가 아닙니다.',
+      };
+    }
+
     return {
       message: '프롬프트 무료 다운로드 완료',
       title: prompt.title,

--- a/src/prompts/services/prompt.download.service.ts
+++ b/src/prompts/services/prompt.download.service.ts
@@ -1,25 +1,18 @@
 import { PromptDownloadRepository } from '../repositories/prompt.download.repository';
 import { PromptDownloadResponseDTO } from '../dtos/prompt.download.dto';
+import { AppError } from '../../errors/AppError';
 
 export const PromptDownloadService = {
   async getPromptContent(userId: number, promptId: number): Promise<PromptDownloadResponseDTO> {
     const prompt = await PromptDownloadRepository.findById(promptId);
 
     if (!prompt) {
-      throw {
-        statusCode: 404,
-        error: 'NotFound',
-        message: '해당 프롬프트를 찾을 수 없습니다.',
-      };
+      throw new AppError('해당 프롬프트를 찾을 수 없습니다.', 404, 'NotFound');
     }
 
     // 유료 프롬프트인 경우 다운로드 불가 처리
     if (!prompt.is_free) {
-      throw {
-        statusCode: 403,
-        error: 'Forbidden',
-        message: '해당 프롬프트는 무료가 아닙니다.',
-      };
+      throw new AppError('해당 프롬프트는 무료가 아닙니다.', 403, 'Forbidden');
     }
 
     return {


### PR DESCRIPTION
## 📌 기능 설명
- [ ] 인증된 사용자만 무료 프롬프트를 조회할 수 있도록 JWT 기반 인증을 적용했습니다.
- [ ] 프롬프트 내용을 성공적으로 조회하면 클라이언트에서 복사하거나 활용할 수 있도록 내용을 반환합니다.

## 📌 구현 내용
- [ ] 무료 프롬프트(is_free: true)만 다운로드 가능하도록 Service 로직에 추가하였습니다.
- [ ] 인증 미들웨어(authenticateJwt)를 도입하였습니다.

## 📌 구현 결과
<img width="882" height="703" alt="image" src="https://github.com/user-attachments/assets/056a598b-4e5f-4f73-b86a-9053020334e3" />
<img width="887" height="687" alt="image" src="https://github.com/user-attachments/assets/adbee576-ab4c-4704-b96b-d5df8690a449" />
<img width="864" height="681" alt="image" src="https://github.com/user-attachments/assets/8c1caa69-bf09-42d4-a122-36f7117a3254" />

## 📌 논의하고 싶은 점
- [ ] 현재는 컨트롤러에서 req.user를 직접 검사하여 미인증 사용자의 접근을 막고 있으나, authenticateJwt 미들웨어를 커스터마이징하여 전역적으로 미인증 사용자에 대해 명확한 에러 메시지를 반환하도록 개선하면 좋을 것 같습니다!