### PR TITLE
Feat/#13

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import authRouter from './auth/routes/auth.route'; // auth 라우터 경로 수�
 import membersRouter from './members/routes/member.route'; // members 라우터 import
 import promptRoutes from './prompts/prompt.route';
 import promptReviewRouter from './reviews/routes/prompt-review.route';
+import promptDownloadRouter from './prompts/routes/prompt.downlaod.route'
 import promptLikeRouter from './prompts/routes/prompt.like.route';
 // import * as swaggerDocument from './docs/swagger/swagger.json'; 
 // import { RegisterRoutes } from './routes/routes'; // tsoa가 생성하는 파일
@@ -50,6 +51,10 @@ const PORT = 3000;
 // 프롬프트 관련 라우터
   // 프롬프트 검색 API
 app.use('/api/prompts', promptRoutes);
+
+  // 프롬프트 무료 다운로드 라우터
+app.use('/api/prompts', promptDownloadRouter);
+
   // 프롬프트 찜 라우터
 app.use('/api/prompts', promptLikeRouter);
 

--- a/src/prompts/controllers/prompt.like.controller.ts
+++ b/src/prompts/controllers/prompt.like.controller.ts
@@ -1,92 +1,56 @@
-import { Request, Response, NextFunction } from 'express';
-import * as promptLikeRepo from '../repositories/prompt.like.repository';
+import { Request, Response } from 'express';
+import { PromptLikeService } from '../services/prompt.like.service';
 
-export const likePrompt = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+export const likePrompt = async (req: Request, res: Response): Promise<void> => {
+  const user = req.user;
+  if (!user) {
+    res.fail({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: '로그인이 필요합니다.',
+    });
+    return;
+  }
+
+  const userId = (req.user as { user_id: number }).user_id;
+  const promptId = parseInt(req.params.promptId, 10);
+
   try {
-    // 인증 여부 검사
-    if (!req.user) {
-        res.status(401).json({
-        error: 'Unauthorized',
-        message: '로그인이 필요합니다.',
-        statusCode: 401,
-      });
-    }
-
-    // 타입 단언 후 user_id 추출
-    const userId = (req.user as { user_id: number }).user_id;
-    const promptId = parseInt(req.params.promptId, 10);
-
-    // 프롬프트 존재 여부 확인
-    const prompt = await promptLikeRepo.findPromptById(promptId);
-    if (!prompt) {
-        res.status(404).json({
-        error: 'NotFound',
-        message: '해당 프롬프트를 찾을 수 없습니다.',
-        statusCode: 404,
-      });
-    }
-
-    // 이미 찜했는지 확인
-    const alreadyLiked = await promptLikeRepo.hasLikedPrompt(userId, promptId);
-    if (alreadyLiked) {
-        res.status(409).json({
-        error: 'Conflict',
-        message: '이미 찜한 프롬프트입니다.',
-        statusCode: 409,
-      });
-    }
-
-    // 찜 등록
-    await promptLikeRepo.addPromptLike(userId, promptId);
-
+    await PromptLikeService.likePrompt(userId, promptId);
     res.status(201).json({
       message: '프롬프트 찜 성공',
       statusCode: 201,
     });
-  } catch (error) {
-    console.error('likePrompt error:', error);
-    res.status(500).json({
-      error: 'InternalServerError',
-      message: '알 수 없는 오류가 발생했습니다.',
-      statusCode: 500,
+  } catch (err: any) {
+    res.fail({
+      statusCode: err.statusCode || 500,
+      error: err.error || 'InternalServerError',
+      message: err.message || '알 수 없는 오류가 발생했습니다.',
     });
   }
 };
 
-export const getLikedPrompts = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-  try {
-    if (!req.user) {
-        res.status(401).json({
-        error: 'Unauthorized',
-        message: '로그인이 필요합니다.',
-        statusCode: 401,
-      });
-    }
-
-    const userId = (req.user as { user_id: number }).user_id;
-
-    const likes = await promptLikeRepo.getLikedPromptsByUser(userId);
-
-    const result = likes.map((like) => ({
-      prompt_id: like.prompt.prompt_id,
-      title: like.prompt.title,
-      description: like.prompt.description,
-      is_free: like.prompt.is_free,
-      download_url: like.prompt.download_url,
-      liked_at: like.created_at,
-    }));
-
-    res.status(200).json({
-      message: '찜한 프롬프트 목록 조회 성공',
-      data: result,
-      statusCode: 200,
+export const getLikedPrompts = async (req: Request, res: Response): Promise<void> => {
+  const user = req.user;
+  if (!user) {
+    res.fail({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: '로그인이 필요합니다.',
     });
-  } catch (error) {
-    console.error('getLikedPrompts error:', error);
-    res.status(500).json({
-      error: 'InternalServerError',
-      message: '알 수 없는 오류가 발생했습니다.',
-      statusCode: 500,
+    return;
+  }
+
+  const userId = (req.user as { user_id: number }).user_id;
+
+  try {
+    const result = await PromptLikeService.getLikedPrompts(userId);
+    res.success(result, '찜한 프롬프트 목록 조회 성공');
+  } catch (err: any) {
+    res.fail({
+      statusCode: err.statusCode || 500,
+      error: err.error || 'InternalServerError',
+      message: err.message || '알 수 없는 오류가 발생했습니다.',
     });
   }
 };

--- a/src/prompts/dtos/prompt.like.dto.ts
+++ b/src/prompts/dtos/prompt.like.dto.ts
@@ -6,10 +6,8 @@ export interface LikePromptResponse {
 export interface LikedPrompt {
   prompt_id: number;
   title: string;
-  description: string;
-  is_free: boolean;
-  download_url: string | null;
-  liked_at: string;
+  models: string[];
+  tags: string[];
 }
 
 export interface GetLikedPromptsResponse {

--- a/src/prompts/repositories/prompt.like.repository.ts
+++ b/src/prompts/repositories/prompt.like.repository.ts
@@ -35,9 +35,20 @@ export const getLikedPromptsByUser = async (userId: number) => {
         select: {
           prompt_id: true,
           title: true,
-          description: true,
-          is_free: true,
-          download_url: true,
+          models: {
+            include: {
+              model: {
+                select: { name: true },
+              },
+            },
+          },
+          tags: {
+            include: {
+              tag: {
+                select: { name: true },
+              },
+            },
+          },
         },
       },
     },

--- a/src/prompts/routes/prompt.downlaod.route.ts
+++ b/src/prompts/routes/prompt.downlaod.route.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
+import { authenticateJwt } from '../../config/passport';
 import { PromptDownloadController } from '../controllers/prompt.download.controller';
 
 const router = Router();
 
-router.get('/:promptId/downloads', PromptDownloadController.getPromptContent);
+router.get('/:promptId/downloads', authenticateJwt, PromptDownloadController.getPromptContent);
 
 export default router;

--- a/src/prompts/routes/prompt.downlaod.route.ts
+++ b/src/prompts/routes/prompt.downlaod.route.ts
@@ -3,6 +3,6 @@ import { PromptDownloadController } from '../controllers/prompt.download.control
 
 const router = Router();
 
-router.get('/prompts/:promptId/downloads', PromptDownloadController.getPromptContent);
+router.get('/:promptId/downloads', PromptDownloadController.getPromptContent);
 
 export default router;

--- a/src/prompts/routes/prompt.like.route.ts
+++ b/src/prompts/routes/prompt.like.route.ts
@@ -3,7 +3,7 @@ import { likePrompt, getLikedPrompts } from '../controllers/prompt.like.controll
 
 const router = Router();
 
-router.post('/prompts/:promptId/likes', likePrompt);
-router.get('/prompts/likes', getLikedPrompts);
+router.post('/:promptId/likes', likePrompt);
+router.get('/likes', getLikedPrompts);
 
 export default router;

--- a/src/prompts/routes/prompt.like.route.ts
+++ b/src/prompts/routes/prompt.like.route.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
+import { authenticateJwt } from '../../config/passport';
 import { likePrompt, getLikedPrompts } from '../controllers/prompt.like.controller';
 
 const router = Router();
 
-router.post('/:promptId/likes', likePrompt);
-router.get('/likes', getLikedPrompts);
+router.post('/:promptId/likes', authenticateJwt, likePrompt);
+router.get('/likes', authenticateJwt, getLikedPrompts);
 
 export default router;

--- a/src/prompts/services/prompt.download.service.ts
+++ b/src/prompts/services/prompt.download.service.ts
@@ -13,6 +13,15 @@ export const PromptDownloadService = {
       };
     }
 
+    // 유료 프롬프트인 경우 다운로드 불가 처리
+    if (!prompt.is_free) {
+      throw {
+        statusCode: 403,
+        error: 'Forbidden',
+        message: '해당 프롬프트는 무료가 아닙니다.',
+      };
+    }
+
     return {
       message: '프롬프트 무료 다운로드 완료',
       title: prompt.title,

--- a/src/prompts/services/prompt.download.service.ts
+++ b/src/prompts/services/prompt.download.service.ts
@@ -1,25 +1,18 @@
 import { PromptDownloadRepository } from '../repositories/prompt.download.repository';
 import { PromptDownloadResponseDTO } from '../dtos/prompt.download.dto';
+import { AppError } from '../../errors/AppError';
 
 export const PromptDownloadService = {
   async getPromptContent(userId: number, promptId: number): Promise<PromptDownloadResponseDTO> {
     const prompt = await PromptDownloadRepository.findById(promptId);
 
     if (!prompt) {
-      throw {
-        statusCode: 404,
-        error: 'NotFound',
-        message: '해당 프롬프트를 찾을 수 없습니다.',
-      };
+      throw new AppError('해당 프롬프트를 찾을 수 없습니다.', 404, 'NotFound');
     }
 
     // 유료 프롬프트인 경우 다운로드 불가 처리
     if (!prompt.is_free) {
-      throw {
-        statusCode: 403,
-        error: 'Forbidden',
-        message: '해당 프롬프트는 무료가 아닙니다.',
-      };
+      throw new AppError('해당 프롬프트는 무료가 아닙니다.', 403, 'Forbidden');
     }
 
     return {

--- a/src/prompts/services/prompt.like.service.ts
+++ b/src/prompts/services/prompt.like.service.ts
@@ -16,16 +16,18 @@ export const PromptLikeService = {
     await promptLikeRepo.addPromptLike(userId, promptId);
   },
 
-  async getLikedPrompts(userId: number) {
+ async getLikedPrompts(userId: number) {
     const likes = await promptLikeRepo.getLikedPromptsByUser(userId);
 
-    return likes.map((like) => ({
-      prompt_id: like.prompt.prompt_id,
-      title: like.prompt.title,
-      description: like.prompt.description,
-      is_free: like.prompt.is_free,
-      download_url: like.prompt.download_url,
-      liked_at: like.created_at,
-    }));
-  }
+    return likes.map((like) => {
+      const prompt = like.prompt;
+
+      return {
+        prompt_id: prompt.prompt_id,
+        title: prompt.title,
+        models: prompt.models.map((m) => m.model.name),
+        tags: prompt.tags.map((t) => t.tag.name),
+      };
+    });
+  },
 };

--- a/src/prompts/services/prompt.like.service.ts
+++ b/src/prompts/services/prompt.like.service.ts
@@ -1,0 +1,31 @@
+import * as promptLikeRepo from '../repositories/prompt.like.repository';
+import { AppError } from '../../errors/AppError';
+
+export const PromptLikeService = {
+  async likePrompt(userId: number, promptId: number): Promise<void> {
+    const prompt = await promptLikeRepo.findPromptById(promptId);
+    if (!prompt) {
+      throw new AppError('해당 프롬프트를 찾을 수 없습니다.', 404, 'NotFound');
+    }
+
+    const alreadyLiked = await promptLikeRepo.hasLikedPrompt(userId, promptId);
+    if (alreadyLiked) {
+      throw new AppError('이미 찜한 프롬프트입니다.', 409, 'Conflict');
+    }
+
+    await promptLikeRepo.addPromptLike(userId, promptId);
+  },
+
+  async getLikedPrompts(userId: number) {
+    const likes = await promptLikeRepo.getLikedPromptsByUser(userId);
+
+    return likes.map((like) => ({
+      prompt_id: like.prompt.prompt_id,
+      title: like.prompt.title,
+      description: like.prompt.description,
+      is_free: like.prompt.is_free,
+      download_url: like.prompt.download_url,
+      liked_at: like.created_at,
+    }));
+  }
+};


### PR DESCRIPTION
## 📌 기능 설명
- [ ] 기존 응답 데이터에서 불필요한 필드 제거
- [ ] 프롬프트의 제목, 모델명, 태그명만 응답하도록 구조 단순화
- [ ] 사용자가 찜한 프롬프트를 등록하고 조회하는 API에 JWT 인증 미들웨어를 적용하여
비인증 사용자의 접근을 차단

## 📌 구현 내용
- [ ] getLikedPromptsByUser 레포지토리 함수에서 PromptModel, PromptTag 관계 포함
- [ ] model.name, tag.name만 가져오도록 select 최적화
- [ ] 응답 DTO(LikedPrompt)를 새 구조에 맞게 수정
- [ ] 기존 description, download_url 등 제거
- [ ] models: string[], tags: string[] 추가

## 📌 구현 결과
<img width="875" height="653" alt="image" src="https://github.com/user-attachments/assets/24c9dbfd-33b3-4cb7-b782-5ff10bfd4096" />
<img width="851" height="682" alt="image" src="https://github.com/user-attachments/assets/e707a738-c56c-4269-ba55-2f0c2f5f346e" />
<img width="890" height="684" alt="image" src="https://github.com/user-attachments/assets/7d6bfc82-eb98-4ec3-a6b7-9e7a4992d84c" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->