### PR TITLE
Feat: 프롬프트 찜 취소하기 API 구현

### DIFF
--- a/src/prompts/controllers/prompt.like.controller.ts
+++ b/src/prompts/controllers/prompt.like.controller.ts
@@ -54,3 +54,28 @@ export const getLikedPrompts = async (req: Request, res: Response): Promise<void
     });
   }
 };
+
+export const unlikePrompt = async (req: Request, res: Response): Promise<void> => {
+  if (!req.user) {
+    res.fail({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: '로그인이 필요합니다.',
+    });
+    return;
+  }
+
+  const userId = (req.user as { user_id: number }).user_id;
+  const promptId = Number(req.params.promptId);
+
+  try {
+    await PromptLikeService.unlikePrompt(userId, promptId);
+    res.success(null, '프롬프트 찜 취소 성공');
+  } catch (err: any) {
+    res.fail({
+      statusCode: err.statusCode || 500,
+      error: err.error || 'InternalServerError',
+      message: err.message || '서버 오류가 발생했습니다.',
+    });
+  }
+};

--- a/src/prompts/repositories/prompt.like.repository.ts
+++ b/src/prompts/repositories/prompt.like.repository.ts
@@ -57,3 +57,14 @@ export const getLikedPromptsByUser = async (userId: number) => {
     },
   });
 };
+
+export const removePromptLike = async (userId: number, promptId: number) => {
+  return prisma.promptLike.delete({
+    where: {
+      user_id_prompt_id: {
+        user_id: userId,
+        prompt_id: promptId,
+      },
+    },
+  });
+};

--- a/src/prompts/routes/prompt.like.route.ts
+++ b/src/prompts/routes/prompt.like.route.ts
@@ -1,10 +1,11 @@
 import { Router } from 'express';
 import { authenticateJwt } from '../../config/passport';
-import { likePrompt, getLikedPrompts } from '../controllers/prompt.like.controller';
+import { likePrompt, getLikedPrompts, unlikePrompt } from '../controllers/prompt.like.controller';
 
 const router = Router();
 
 router.post('/:promptId/likes', authenticateJwt, likePrompt);
 router.get('/likes', authenticateJwt, getLikedPrompts);
+router.delete('/:promptId/likes', authenticateJwt, unlikePrompt);
 
 export default router;

--- a/src/prompts/services/prompt.like.service.ts
+++ b/src/prompts/services/prompt.like.service.ts
@@ -30,4 +30,13 @@ export const PromptLikeService = {
       };
     });
   },
+
+   async unlikePrompt(userId: number, promptId: number): Promise<void> {
+    const existing = await promptLikeRepo.hasLikedPrompt(userId, promptId);
+    if (!existing) {
+      throw new AppError('찜하지 않은 프롬프트입니다.', 404, 'NotFound');
+    }
+
+    await promptLikeRepo.removePromptLike(userId, promptId);
+  },
 };


### PR DESCRIPTION
## 📌 기능 설명
사용자가 찜한 프롬프트를 취소할 수 있는 API를 추가했습니다.
JWT 인증이 적용되며, 본인이 찜한 프롬프트에 한해서만 찜 취소가 가능합니다.

## 📌 구현 내용
- [ ] DELETE /prompts/:promptId/likes 라우트 추가
- [ ] PromptLikeService.unlikePrompt 서비스 로직 구현
- [ ] 찜 기록이 없을 경우 404 NotFound 에러 발생
- [ ] promptLikeRepo.removePromptLike 레포지토리 함수 추가
- [ ] 컨트롤러에서 res.success 및 AppError 기반 오류 응답 처리
- [ ] 인증 미들웨어(authenticateJwt) 적용 → 비로그인 사용자 접근 차단

## 📌 구현 결과
<img width="1502" height="624" alt="image" src="https://github.com/user-attachments/assets/77774425-2d20-418a-b57b-f444158df5c7" />
<img width="1498" height="599" alt="image" src="https://github.com/user-attachments/assets/5f868773-3e9b-4ec9-a931-cc2402e87d72" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->