### PR TITLE
feat: UserProfile 테이블 UserHistory, UserIntros 테이블로 분리

### DIFF
--- a/prisma/migrations/20250722075218_separate_user_profile/migration.sql
+++ b/prisma/migrations/20250722075218_separate_user_profile/migration.sql
@@ -1,0 +1,41 @@
+/*
+  Warnings:
+
+  - You are about to drop the `UserProfile` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE `UserProfile` DROP FOREIGN KEY `UserProfile_user_id_fkey`;
+
+-- DropTable
+DROP TABLE `UserProfile`;
+
+-- CreateTable
+CREATE TABLE `UserIntro` (
+    `intro_id` INTEGER NOT NULL AUTO_INCREMENT,
+    `user_id` INTEGER NOT NULL,
+    `description` VARCHAR(255) NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `UserIntro_user_id_key`(`user_id`),
+    PRIMARY KEY (`intro_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `UserHistory` (
+    `history_id` INTEGER NOT NULL AUTO_INCREMENT,
+    `user_id` INTEGER NOT NULL,
+    `history` VARCHAR(191) NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `UserHistory_user_id_key`(`user_id`),
+    PRIMARY KEY (`history_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `UserIntro` ADD CONSTRAINT `UserIntro_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `User`(`user_id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserHistory` ADD CONSTRAINT `UserHistory_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `User`(`user_id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250722075354_change_user_history_to_one_to_many/migration.sql
+++ b/prisma/migrations/20250722075354_change_user_history_to_one_to_many/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX `UserHistory_user_id_key` ON `UserHistory`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,7 +37,8 @@ model User {
   role          Role      @default(USER)
 
   // Relations
-  profile            UserProfile?
+  intro              UserIntro?
+  history            UserHistory[]
   profileImage       UserImage?
   sns_list           UserSNS[]
   followings         Following[]       @relation("Follower")
@@ -59,15 +60,24 @@ model User {
   refreshTokens      RefreshToken[]
 }
 
-model UserProfile {
-  profile_id  Int      @id @default(autoincrement())
+model UserIntro {
+  intro_id    Int      @id @default(autoincrement())
   user_id     Int      @unique
   description String   @db.VarChar(255)
-  history     String
   created_at  DateTime @default(now())
   updated_at  DateTime @updatedAt
 
-  user User @relation(fields: [user_id], references: [user_id])
+  user User @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+}
+
+model UserHistory {
+  history_id Int      @id @default(autoincrement())
+  user_id    Int
+  history    String
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  user User @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
 }
 
 model UserSNS {

--- a/src/members/repositories/member.repository.ts
+++ b/src/members/repositories/member.repository.ts
@@ -5,7 +5,7 @@ class MemberRepository {
     return prisma.user.findUnique({
       where: { user_id: memberId },
       include: {
-        profile: true, // UserProfile 정보를 함께 가져옴
+        intro: true, // UserIntro 정보 포함
       },
     });
   }

--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -28,7 +28,7 @@ class MemberService {
       email: member.email,
       name: member.name,
       nickname: member.nickname,
-      intros: member.profile?.description || null,
+      intros: member.intro?.description || null, // member.profile.description 대신 member.intro.description 사용
       created_at: member.created_at,
       updated_at: member.updated_at,
       status: member.status,


### PR DESCRIPTION
## 📌 기능 설명
기존에 단일 테이블로 관리되던 `UserProfile`(회원 한 줄 소개, 이력)을 데이터 모델링 개선을 위해 두 개의 독립적인 테이블로 분리하는 리팩토링을 진행했습니다.

-   **`UserIntro`**: 회원의 한 줄 소개를 관리합니다. (User와 1:1 관계)
-   **`UserHistory`**: 회원의 이력(경력 등)을 관리합니다. (User와 1:N 관계)

이번 리팩토링을 통해 데이터 구조의 명확성을 높이고, 각 데이터의 특성에 맞는 확장성 있는 구조를 확보했습니다.

## 📌 구현 내용

### 1. **Prisma 스키마 리팩토링**
-   `prisma/schema.prisma` 파일에서 기존 `UserProfile` 모델을 삭제했습니다.
-   `UserIntro`와 `UserHistory` 모델을 새로 정의하고, `User` 모델과의 관계를 각각 1:1과 1:N으로 설정했습니다.
    ```prisma
    model User {
      // ... 기존 필드
      intro    UserIntro?     // 1:1 관계
      history  UserHistory[]  // 1:N 관계
      // ...
    }

    model UserIntro {
      intro_id    Int      @id @default(autoincrement())
      user_id     Int      @unique
      description String   @db.VarChar(255)
      // ...
      user User @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
    }

    model UserHistory {
      history_id Int      @id @default(autoincrement())
      user_id    Int      // unique 제약조건 제거
      history    String
      // ...
      user User @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
    }
    ```

### 2. **데이터베이스 마이그레이션**
-   스키마 변경에 따라 `separate-user-profile`, `change-user-history-to-one-to-many` 두 개의 마이그레이션을 생성하고 실행하여 데이터베이스에 변경 사항을 적용했습니다.

### 3. **기존 코드 수정**
-   스키마 변경으로 인해 영향을 받는 기존 코드를 수정했습니다.
-   `src/members/repositories/member.repository.ts`의 `findMemberById` 함수가 `UserProfile` 대신 `UserIntro`를 `include` 하도록 변경했습니다.
-   `src/members/services/member.service.ts`의 `getMemberProfile` 서비스가 `member.profile.description` 대신 `member.intro.description`을 참조하도록 수정하여, 회원 정보 조회 API가 정상적으로 동작하도록 유지했습니다.

## 📌 구현 결과
-   백엔드 리팩토링으로 별도의 UI 변경 사항은 없습니다.
-   Postman을 통해 기존의 회원 정보 조회 API(`GET /api/members/:memberId`)가 새로운 DB 구조에서도 이전과 동일하게 정상적으로 응답하는 것을 확인했습니다.

## 📌 논의하고 싶은 점
