### PR TITLE
회원 이력 작성, 수정, 삭제 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@aws-sdk/s3-request-presigner": "^3.848.0",
     "@types/express-session": "^1.18.2",
     "@types/passport-google-oauth20": "^2.0.16",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.2",
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
     "express-session": "^1.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@types/passport-google-oauth20':
         specifier: ^2.0.16
         version: 2.0.16
+      class-transformer:
+        specifier: ^0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: ^0.14.2
+        version: 0.14.2
       dotenv:
         specifier: ^17.0.1
         version: 17.2.0
@@ -763,6 +769,9 @@ packages:
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
+  '@types/validator@13.15.2':
+    resolution: {integrity: sha512-y7pa/oEJJ4iGYBxOpfAKn5b9+xuihvzDVnC/OSvlVnGxVg0pOqmjiMafiJ1KVNQEaPZf9HsEp5icEwGg8uIe5Q==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -877,6 +886,12 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  class-transformer@0.5.1:
+    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
+
+  class-validator@0.14.2:
+    resolution: {integrity: sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1238,6 +1253,9 @@ packages:
 
   jws@3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
+
+  libphonenumber-js@1.12.10:
+    resolution: {integrity: sha512-E91vHJD61jekHHR/RF/E83T/CMoaLXT7cwYA75T4gim4FZjnM6hbJjVIGg7chqlSqRsSvQ3izGmOjHy1SQzcGQ==}
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
@@ -3082,6 +3100,8 @@ snapshots:
 
   '@types/uuid@9.0.8': {}
 
+  '@types/validator@13.15.2': {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -3208,6 +3228,14 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  class-transformer@0.5.1: {}
+
+  class-validator@0.14.2:
+    dependencies:
+      '@types/validator': 13.15.2
+      libphonenumber-js: 1.12.10
+      validator: 13.15.15
 
   cliui@8.0.1:
     dependencies:
@@ -3631,6 +3659,8 @@ snapshots:
     dependencies:
       jwa: 1.4.2
       safe-buffer: 5.2.1
+
+  libphonenumber-js@1.12.10: {}
 
   lodash.get@4.4.2: {}
 

--- a/src/members/dtos/create-history.dto.ts
+++ b/src/members/dtos/create-history.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateHistoryDto {
+  @IsString({ message: '이력은 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: '이력은 필수 입력 항목입니다.' })
+  history!: string;
+} 

--- a/src/members/dtos/update-history.dto.ts
+++ b/src/members/dtos/update-history.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class UpdateHistoryDto {
+  @IsString({ message: '이력은 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: '이력은 필수 입력 항목입니다.' })
+  history!: string;
+} 

--- a/src/members/repositories/member.repository.ts
+++ b/src/members/repositories/member.repository.ts
@@ -42,6 +42,42 @@ class MemberRepository {
       data: { description: intro },
     });
   }
+
+  async createHistory(userId: number, history: string) {
+    return prisma.userHistory.create({
+      data: {
+        user_id: userId,
+        history: history,
+      },
+    });
+  }
+
+  async findHistoryById(historyId: number) {
+    return prisma.userHistory.findUnique({
+      where: { history_id: historyId },
+    });
+  }
+
+  async updateHistory(historyId: number, userId: number, history: string) {
+    return prisma.userHistory.update({
+      where: {
+        history_id: historyId,
+        user_id: userId,
+      },
+      data: {
+        history: history,
+      },
+    });
+  }
+
+  async deleteHistory(historyId: number, userId: number) {
+    return prisma.userHistory.delete({
+      where: {
+        history_id: historyId,
+        user_id: userId,
+      },
+    });
+  }
 }
 
 export default new MemberRepository();

--- a/src/members/routes/member.route.ts
+++ b/src/members/routes/member.route.ts
@@ -56,4 +56,13 @@ router.post('/intros', authenticateJwt, MemberController.upsertIntro);
 // 한줄 소개 수정
 router.patch('/intros', authenticateJwt, MemberController.updateIntro);
 
+// 이력 작성
+router.post('/histories', authenticateJwt, MemberController.createHistory);
+
+// 이력 수정
+router.patch('/histories/:historyId', authenticateJwt, MemberController.updateHistory);
+
+// 이력 삭제
+router.delete('/histories/:historyId', authenticateJwt, MemberController.deleteHistory);
+
 export default router; 


### PR DESCRIPTION
## 📌 기능 설명

회원 프로필에 표시될 이력(History) 정보를 관리하는 API를 구현했습니다. 사용자는 자신의 이력을 생성, 수정, 삭제할 수 있습니다.

## 📌 구현 내용

**주요 구현 파일**

-   `src/members/controllers/member.controller.ts`
-   `src/members/services/member.service.ts`
-   `src/members/repositories/member.repository.ts`
-   `src/members/routes/member.route.ts`
-   `src/members/dtos/create-history.dto.ts`
-   `src/members/dtos/update-history.dto.ts`

**API 엔드포인트**

1.  **이력 생성 (Create)**
    -   `POST /api/members/histories`
    -   요청 본문에 `history` 문자열을 받아 새로운 이력을 생성합니다.
    -   `class-validator`를 이용해 요청 데이터의 유효성을 검사합니다.

2.  **이력 수정 (Update)**
    -   `PATCH /api/members/histories/:historyId`
    -   URL 파라미터로 받은 `historyId`에 해당하는 이력의 `history` 내용을 수정합니다.
    -   자신의 이력만 수정할 수 있도록 소유권을 확인하는 로직이 포함되어 있습니다.

3.  **이력 삭제 (Delete)**
    -   `DELETE /api/members/histories/:historyId`
    -   URL 파라미터로 받은 `historyId`에 해당하는 이력을 삭제합니다.
    -   자신의 이력만 삭제할 수 있도록 소유권을 확인하는 로직이 포함되어 있습니다.

**공통 사항**
- 모든 API는 `authenticateJwt` 미들웨어를 통해 JWT 인증을 거친 사용자만 접근할 수 있습니다.
- `AppError`를 사용하여 존재하지 않는 리소스(`440 Not Found`), 권한 없음(`403 Forbidden`), 잘못된 요청(`400 Bad Request`) 등 다양한 예외 상황을 처리합니다.

## 📌 구현 결과

백엔드 API 구현으로 별도의 UI 변경 사항은 없습니다. API는 명세서에 따라 정상적으로 작동하며, Postman 등을 통해 테스트할 수 있습니다.

<img width="1446" height="695" alt="image" src="https://github.com/user-attachments/assets/a33551db-6335-4340-bdec-8058755f46d8" />


## 📌 논의하고 싶은 점

-   개발 초기 단계에서 `UserHistory` 모델의 스키마를 `history` 필드에서 `year`와 `title` 필드로 변경하려다 Prisma 마이그레이션 충돌 문제를 겪었습니다. 결국 기존 스키마를 유지하는 것으로 결정했는데, 추후 이력 데이터를 구조화할 필요가 있다면 마이그레이션 전략에 대해 다시 논의해보면 좋겠습니다.
-   현재는 이력 생성, 수정, 삭제 기능만 구현되어 있습니다. 특정 사용자의 전체 이력 목록을 조회하는 API(`GET /api/members/:memberId/histories`)도 추가로 구현이 필요할 것 같습니다.