### PR TITLE
feat:프롬프트 리뷰 목록 가져오기 구현(#49)

### DIFF
--- a/src/reviews/controllers/review.controller.ts
+++ b/src/reviews/controllers/review.controller.ts
@@ -2,7 +2,8 @@ import { Request, Response } from 'express';
 import {
   findReviewsByPromptId,
   createReviewService,
-  deleteReviewService
+  deleteReviewService,
+  getReviewEditDataService
 } from '../services/review.service';
 
 interface RawPromptParams {
@@ -127,3 +128,43 @@ export const deleteReview = async (
   }
 };
 
+
+// 리뷰 수정 화면
+export const getReviewEditData = async (
+  req: Request<{ reviewId: string }, any, any>,
+  res: Response
+): Promise<void> => {
+  if (!req.user) {
+    res.fail({
+      statusCode: 401,
+      error: 'no user',
+      message: '로그인이 필요합니다.',
+    });
+    return;
+  }
+
+  try {
+    const reviewId = req.params.reviewId;
+
+    if (!reviewId) {
+      res.status(400).json({ message: '리뷰 ID가 없습니다.' });
+      return;
+    }
+
+    const review = await getReviewEditDataService(
+      reviewId,
+      (req.user as {user_id: number}).user_id
+    );
+
+    res.success({
+      data: review,
+    });
+  } catch (err: any) {
+    console.error(err);
+    res.fail({
+      error: err.name || 'InternalServerError',
+      message: err.message || '리뷰 수정 화면을 불러오는 중 오류가 발생했습니다.',
+      statusCode: err.statusCode || 500,
+    });
+  }
+};

--- a/src/reviews/dtos/review.dtos.ts
+++ b/src/reviews/dtos/review.dtos.ts
@@ -1,4 +1,6 @@
-import { Review } from '@prisma/client';
+
+import { Review, Prompt } from '@prisma/client';
+import e from 'express';
 
 
 export interface ReviewResponse {
@@ -68,3 +70,41 @@ export const mapToReviewResponse = (review: Review): ReviewResponse => ({
   content: review.content,
   createdAt: review.created_at
 });
+
+// 리뷰 수정 화면 데이터 반환 타입
+export interface ReviewEditDataDTO {
+  prompter_id: number;
+  prompter_nickname: string;
+  prompt_id: number;
+  model_id: number;
+  model_name: string;
+  rating_avg: string;
+  content: string;
+}
+
+// 리뷰 수정 화면 데이터 반환 dto
+export const mapToReviewEditDataDTO = ({
+  review,
+  prompt,
+  modelId,
+  modelName,
+  prompterId,
+  prompterNickname
+}: {
+  review: Review;
+  prompt: Prompt;
+  modelId: number;
+  modelName: string;
+  prompterId: number;
+  prompterNickname: string;
+}): ReviewEditDataDTO => {
+  return {
+    prompter_id: prompterId,
+    prompter_nickname: prompterNickname,
+    prompt_id: prompt.prompt_id,
+    model_id: modelId,
+    model_name: modelName,
+    rating_avg: prompt.rating_avg.toFixed(1), // 소수점 첫째 자리까지(string)
+    content: review.content,
+  };
+};

--- a/src/reviews/repositories/review.repository.ts
+++ b/src/reviews/repositories/review.repository.ts
@@ -1,3 +1,4 @@
+
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
@@ -36,17 +37,6 @@ export const findAllByPromptId = async (
   });
 };
 
-export const findNicknameByUserId = async (userIds: number[]) => {
-  return await prisma.user.findMany({
-    where: {
-      user_id: { in: userIds }
-    },
-    select: {
-      user_id: true,
-      nickname: true
-    }
-  });
-};
 
 
 // 리뷰 작성자들의 닉네임 + 프로필 이미지 URL 조회
@@ -99,3 +89,49 @@ export const deleteReviewById = async (reviewId: number) => {
     }
   });
 };
+
+export const findPromptByReviewId = async (reviewId: number) => {
+  return await prisma.prompt.findUnique({
+    where: {
+      prompt_id: reviewId
+    }
+  });
+};
+
+// 사용자 ID로 닉네임만 조회
+export const findNicknameByUserId = async (userId: number): Promise<string | null> => {
+  const user = await prisma.user.findUnique({
+    where: {
+      user_id: userId
+    },
+    select: {
+      nickname: true
+    }
+  });
+
+  return user?.nickname || null;
+};
+
+
+// 프롬프트 ID로 모델 조회
+
+export const findModelByPromptId = async (promptId: number): Promise<{ model_id: number; model_name: string } | null> => {
+  const promptModel = await prisma.promptModel.findFirst({
+    where: { prompt_id: promptId },
+    include: {
+      model: {
+        select: {
+          model_id: true,
+          name: true
+        }
+      }
+    }
+  });
+  if(!promptModel?.model) return null;
+
+  return {
+    model_id: promptModel.model.model_id,
+    model_name: promptModel.model.name
+  };
+};
+

--- a/src/reviews/routes/review.route.ts
+++ b/src/reviews/routes/review.route.ts
@@ -3,7 +3,8 @@ import { authenticateJwt } from '../../config/passport';
 import { 
     getReviewsByPromptId,
     postReview,
-    deleteReview
+    deleteReview,
+    getReviewEditData
 } from '../controllers/review.controller';
 
 const router = express.Router();
@@ -11,4 +12,5 @@ const router = express.Router();
 router.get('/:promptId', authenticateJwt, getReviewsByPromptId);
 router.post('/:promptId', authenticateJwt, postReview);
 router.delete('/:reviewId', authenticateJwt, deleteReview);
+router.get('/:reviewId/edit', authenticateJwt, getReviewEditData);
 export default router;


### PR DESCRIPTION
## 📌 기능 설명
내가 작성한 리뷰를 수정할 때 가져올 데이터(프롬프트 정보 + 작성된 리뷰 데이터)

## 📌 구현 내용
- 프롬프트 정보를 불러와서 prompt_id를 통해 해당 프롬프트를 작성한 프롬프터의 id와 닉네임 추출
- 리뷰 정보를 불러옴
- 불러온 정보들을 dto로 합친 후 응답형식으로 반환

## 📌 구현 결과
<img width="2607" height="1388" alt="스크린샷 2025-07-24 165243" src="https://github.com/user-attachments/assets/21ccf802-2c22-4546-98e0-bd202a3ad8e7" />


## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->