### PR TITLE
Feat: 회원 팔로우, 언팔로우 기능 구현

### DIFF
--- a/src/members/controllers/member.controller.ts
+++ b/src/members/controllers/member.controller.ts
@@ -131,4 +131,24 @@ export class MemberController {
       next(error);
     }
   }
+
+  public async unfollowUser(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const followerUser = req.user as any;
+      const followingId = parseInt(req.params.memberId, 10);
+
+      if (isNaN(followingId)) {
+        throw new AppError('BadRequest', '유효하지 않은 회원 ID입니다.', 400);
+      }
+
+      await this.memberService.unfollowUser(followerUser.user_id, followingId);
+
+      res.status(200).json({
+        message: '언팔로우가 완료되었습니다.',
+        statusCode: 200,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 } 

--- a/src/members/controllers/member.controller.ts
+++ b/src/members/controllers/member.controller.ts
@@ -110,4 +110,25 @@ export class MemberController {
       next(error);
     }
   }
+
+  public async followUser(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const followerUser = req.user as any;
+      const followingId = parseInt(req.params.memberId, 10);
+
+      if (isNaN(followingId)) {
+        throw new AppError('BadRequest', '유효하지 않은 회원 ID입니다.', 400);
+      }
+
+      const follow = await this.memberService.followUser(followerUser.user_id, followingId);
+
+      res.status(200).json({
+        message: '팔로우가 완료되었습니다.',
+        data: follow,
+        statusCode: 200,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 } 

--- a/src/members/repositories/member.repository.ts
+++ b/src/members/repositories/member.repository.ts
@@ -138,4 +138,13 @@ export class MemberRepository {
       },
     });
   }
+
+  async unfollowUser(followerId: number, followingId: number) {
+    return prisma.following.deleteMany({
+      where: {
+        follower_id: followerId,
+        following_id: followingId,
+      },
+    });
+  }
 }

--- a/src/members/repositories/member.repository.ts
+++ b/src/members/repositories/member.repository.ts
@@ -120,4 +120,22 @@ export class MemberRepository {
       where: { user_id: userId },
     });
   }
+
+  async findFollowing(followerId: number, followingId: number) {
+    return prisma.following.findFirst({
+      where: {
+        follower_id: followerId,
+        following_id: followingId,
+      },
+    });
+  }
+
+  async followUser(followerId: number, followingId: number) {
+    return prisma.following.create({
+      data: {
+        follower_id: followerId,
+        following_id: followingId,
+      },
+    });
+  }
 }

--- a/src/members/routes/member.route.ts
+++ b/src/members/routes/member.route.ts
@@ -21,4 +21,8 @@ router.get('/:memberId/sns', passport.authenticate('jwt', { session: false }), (
   memberController.getSnsList(req, res, next)
 );
 
+router.post('/follows/:memberId', passport.authenticate('jwt', { session: false }), (req, res, next) =>
+  memberController.followUser(req, res, next)
+);
+
 export default router; 

--- a/src/members/routes/member.route.ts
+++ b/src/members/routes/member.route.ts
@@ -25,4 +25,8 @@ router.post('/follows/:memberId', passport.authenticate('jwt', { session: false 
   memberController.followUser(req, res, next)
 );
 
+router.delete('/follows/:memberId', passport.authenticate('jwt', { session: false }), (req, res, next) =>
+  memberController.unfollowUser(req, res, next)
+);
+
 export default router; 

--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -63,4 +63,18 @@ export class MemberService {
 
     return this.memberRepository.followUser(followerId, followingId);
   }
+
+  async unfollowUser(followerId: number, followingId: number) {
+    const followingUser = await this.memberRepository.findMemberById(followingId);
+    if (!followingUser) {
+      throw new AppError('NotFound', '해당 사용자를 찾을 수 없습니다.', 404);
+    }
+
+    const existingFollow = await this.memberRepository.findFollowing(followerId, followingId);
+    if (!existingFollow) {
+      throw new AppError('NotFound', '팔로우 관계를 찾을 수 없습니다.', 404);
+    }
+
+    return this.memberRepository.unfollowUser(followerId, followingId);
+  }
 } 

--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -45,4 +45,22 @@ export class MemberService {
   async getSnsList(userId: number) {
     return this.memberRepository.getSnsListByUserId(userId);
   }
+
+  async followUser(followerId: number, followingId: number) {
+    if (followerId === followingId) {
+      throw new AppError('BadRequest', '자기 자신을 팔로우할 수 없습니다.', 400);
+    }
+
+    const followingUser = await this.memberRepository.findMemberById(followingId);
+    if (!followingUser) {
+      throw new AppError('NotFound', '해당 사용자를 찾을 수 없습니다.', 404);
+    }
+
+    const existingFollow = await this.memberRepository.findFollowing(followerId, followingId);
+    if (existingFollow) {
+      throw new AppError('Conflict', '이미 팔로우한 사용자입니다.', 409);
+    }
+
+    return this.memberRepository.followUser(followerId, followingId);
+  }
 } 


### PR DESCRIPTION
## 📌 기능 설명

회원 간의 소셜 상호작용을 위한 팔로우/언팔로우 기능을 구현했습니다. 사용자는 다른 사용자를 팔로우하여 소셜 관계를 맺거나, 기존의 팔로우 관계를 취소할 수 있습니다. 이를 통해 플랫폼 내 커뮤니티 기능을 강화하고 사용자 간의 네트워킹을 활성화합니다.

## 📌 구현 내용

회원 팔로우 및 언팔로우를 위한 REST API를 `Express` 프레임워크 기반으로 구현했습니다.

**API Endpoints**

-   `POST /api/members/follows/{member-id}`: 특정 회원을 팔로우합니다.
-   `DELETE /api/members/follows/{member-id}`: 특정 회원을 언팔로우합니다.

**주요 구현 사항**

-   **Controller (`member.controller.ts`)**:
    -   팔로우/언팔로우 요청을 처리하는 `followUser`, `unfollowUser` 핸들러 메서드를 구현했습니다.
-   **Service (`member.service.ts`)**:
    -   자기 자신을 팔로우하거나 존재하지 않는 사용자를 대상으로 하는 예외 케이스를 처리했습니다.
    -   이미 팔로우 중인 사용자를 다시 팔로우하려고 할 때 `Conflict` 에러를 반환하여 중복 관계 생성을 방지합니다.
    -   언팔로우 시, 실제 팔로우 관계가 존재하는지 먼저 확인하여 `NotFound` 에러를 반환하는 로직을 추가했습니다.
-   **Repository (`member.repository.ts`)**:
    -   Prisma를 사용하여 `Following` 테이블에 팔로우 관계를 생성(`followUser`), 조회(`findFollowing`), 삭제(`unfollowUser`)하는 메서드를 구현했습니다.
-   **Router (`member.route.ts`)**:
    -   위 엔드포인트에 대한 라우팅 규칙을 설정하고, `passport.authenticate`를 통해 JWT 인증을 적용했습니다.

## 📌 구현 결과

API 명세서에 따라 모든 기능이 정상적으로 작동하는 것을 확인했습니다.

**팔로우 성공 시 (`POST /api/members/follows/{member-id}`)**

<img width="966" height="638" alt="image" src="https://github.com/user-attachments/assets/c654da47-3d01-4f3e-b632-4193b775992c" />

**언팔로우 성공 시 (`DELETE /api/members/follows/{member-id}`)**

<img width="972" height="518" alt="image" src="https://github.com/user-attachments/assets/c64a17ed-24ac-4ed9-94ea-2bf53d5ce85d" />

## 📌 논의하고 싶은 점
-   회원 관련 기능이 계속 추가됨에 따라 `member.route.ts` 파일이 비대해질 수 있습니다. 추후 기능별(예: 프로필, 팔로우)로 라우트 파일을 분리하는 리팩토링을 고려해봐도 좋을 것 같습니다.