### PR TITLE
Feat: 회원 팔로잉, 팔로우 목록 조회

### DIFF
--- a/src/members/controllers/member.controller.ts
+++ b/src/members/controllers/member.controller.ts
@@ -44,4 +44,18 @@ export class MemberController {
       next(error);
     }
   }
+
+  public async getFollowings(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const memberId = parseInt(req.params.memberId, 10);
+      const followings = await this.memberService.getFollowings(memberId);
+      res.status(200).json({
+        message: '팔로잉 목록 조회 완료',
+        data: followings,
+        statusCode: 200,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 } 

--- a/src/members/dtos/follower.dto.ts
+++ b/src/members/dtos/follower.dto.ts
@@ -1,0 +1,22 @@
+
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FollowerDto {
+  @ApiProperty({ description: '팔로우 ID' })
+  follow_id: number;
+
+  @ApiProperty({ description: '팔로워 ID' })
+  follower_id: number;
+
+  @ApiProperty({ description: '닉네임' })
+  nickname: string;
+
+  @ApiProperty({ description: '이메일' })
+  email: string;
+
+  @ApiProperty({ description: '생성일' })
+  created_at: Date;
+
+  @ApiProperty({ description: '수정일' })
+  updated_at: Date;
+} 

--- a/src/members/repositories/member.repository.ts
+++ b/src/members/repositories/member.repository.ts
@@ -108,4 +108,24 @@ export class MemberRepository {
       },
     });
   }
+
+  async findFollowingsByMemberId(memberId: number) {
+    return prisma.following.findMany({
+      where: {
+        follower_id: memberId,
+      },
+      select: {
+        follow_id: true,
+        following_id: true,
+        created_at: true,
+        updated_at: true,
+        following: {
+          select: {
+            nickname: true,
+            email: true,
+          },
+        },
+      },
+    });
+  }
 }

--- a/src/members/repositories/member.repository.ts
+++ b/src/members/repositories/member.repository.ts
@@ -1,123 +1,64 @@
+import { Service } from 'typedi';
 import { CreateHistoryDto } from '../dtos/create-history.dto';
 import { UpdateHistoryDto } from '../dtos/update-history.dto';
 import prisma from '../../config/prisma';
 import { CreateSnsDto } from '../dtos/create-sns.dto';
 import { UpdateSnsDto } from '../dtos/update-sns.dto';
+import { User } from '@prisma/client';
 
+@Service()
 export class MemberRepository {
-  async findMemberById(userId: number) {
-    const member = await prisma.user.findUnique({
-      where: { user_id: userId },
-      include: {
-        intro: true, // UserIntro 정보 포함
-      },
-    });
-    return member;
-  }
-
-  async upsertProfileImage(userId: number, imageUrl: string): Promise<void> {
-    await prisma.userImage.upsert({
-      where: { userId },
-      update: { url: imageUrl },
-      create: { userId, url: imageUrl },
-    });
-  }
-
-  async softDeleteUser(userId: number): Promise<void> {
-    await prisma.user.update({
-      where: { user_id: userId },
-      data: {
-        status: false,
-        inactive_date: new Date(),
-      },
-    });
-  }
-
-  async upsertUserIntro(userId: number, intro: string) {
-    return prisma.userIntro.upsert({
-      where: { user_id: userId },
-      update: { description: intro },
-      create: { user_id: userId, description: intro },
-    });
-  }
-
-  async updateUserIntro(userId: number, intro: string) {
-    return prisma.userIntro.update({
-      where: { user_id: userId },
-      data: { description: intro },
-    });
-  }
-
-  async createHistory(userId: number, history: string) {
-    return prisma.userHistory.create({
-      data: {
-        user_id: userId,
-        history: history,
-      },
-    });
-  }
-
-  async findHistoryById(historyId: number) {
-    return prisma.userHistory.findUnique({
-      where: { history_id: historyId },
-    });
-  }
-
-  async updateHistory(historyId: number, userId: number, history: string) {
-    return prisma.userHistory.update({
-      where: {
-        history_id: historyId,
-        user_id: userId,
-      },
-      data: {
-        history: history,
-      },
-    });
-  }
-
-  async deleteHistory(historyId: number, userId: number) {
-    return prisma.userHistory.delete({
-      where: {
-        history_id: historyId,
-        user_id: userId,
-      },
-    });
+  async findSnsByUserId(userId: number) {
+    return await prisma.userSNS.findMany({ where: { user_id: userId } });
   }
 
   async createSns(userId: number, createSnsDto: CreateSnsDto) {
-    const { url, description } = createSnsDto;
-
-    return prisma.userSNS.create({
+    return await prisma.userSNS.create({
       data: {
         user_id: userId,
-        url,
-        description,
+        ...createSnsDto,
       },
-    });
-  }
-
-  async findSnsById(snsId: number) {
-    return prisma.userSNS.findUnique({
-      where: { sns_id: snsId },
     });
   }
 
   async updateSns(snsId: number, updateSnsDto: UpdateSnsDto) {
-    return prisma.userSNS.update({
+    return await prisma.userSNS.update({
       where: { sns_id: snsId },
       data: updateSnsDto,
     });
   }
 
   async deleteSns(snsId: number) {
-    return prisma.userSNS.delete({
-      where: { sns_id: snsId },
+    return await prisma.userSNS.delete({ where: { sns_id: snsId } });
+  }
+
+  async findHistoriesByUserId(userId: number) {
+    return await prisma.userHistory.findMany({ where: { user_id: userId } });
+  }
+
+  async createHistory(userId: number, createHistoryDto: CreateHistoryDto) {
+    return await prisma.userHistory.create({
+      data: {
+        user_id: userId,
+        ...createHistoryDto,
+      },
     });
   }
 
-  async getSnsListByUserId(userId: number) {
-    return prisma.userSNS.findMany({
-      where: { user_id: userId },
+  async updateHistory(historyId: number, updateHistoryDto: UpdateHistoryDto) {
+    return await prisma.userHistory.update({
+      where: { history_id: historyId },
+      data: updateHistoryDto,
+    });
+  }
+
+  async deleteHistory(historyId: number) {
+    return await prisma.userHistory.delete({ where: { history_id: historyId } });
+  }
+
+  async findUserById(memberId: number): Promise<User | null> {
+    return prisma.user.findUnique({
+      where: { user_id: memberId },
     });
   }
 
@@ -144,6 +85,26 @@ export class MemberRepository {
       where: {
         follower_id: followerId,
         following_id: followingId,
+      },
+    });
+  }
+
+  async findFollowersByMemberId(memberId: number) {
+    return prisma.following.findMany({
+      where: {
+        following_id: memberId,
+      },
+      select: {
+        follow_id: true,
+        follower_id: true,
+        created_at: true,
+        updated_at: true,
+        follower: {
+          select: {
+            nickname: true,
+            email: true,
+          },
+        },
       },
     });
   }

--- a/src/members/routes/member.route.ts
+++ b/src/members/routes/member.route.ts
@@ -21,4 +21,10 @@ router.delete(
   memberController.unfollowUser.bind(memberController),
 );
 
+router.get(
+  '/following/:memberId',
+  authenticateJwt,
+  memberController.getFollowings.bind(memberController),
+);
+
 export default router; 

--- a/src/members/routes/member.route.ts
+++ b/src/members/routes/member.route.ts
@@ -1,32 +1,24 @@
-import express from 'express';
+import { Router } from 'express';
 import { MemberController } from '../controllers/member.controller';
-import passport from 'passport';
+import { authenticateJwt } from '../../config/passport';
 
-const router = express.Router();
+const router = Router();
 const memberController = new MemberController();
 
-router.post('/sns', passport.authenticate('jwt', { session: false }), (req, res, next) =>
-  memberController.createSns(req, res, next)
+router.get(
+  '/followers/:memberId',
+  authenticateJwt,
+  memberController.getFollowers.bind(memberController),
 );
-
-router.patch('/sns/:snsId', passport.authenticate('jwt', { session: false }), (req, res, next) =>
-  memberController.updateSns(req, res, next)
+router.post(
+  '/follow/:memberId',
+  authenticateJwt,
+  memberController.followUser.bind(memberController),
 );
-
-router.delete('/sns/:snsId', passport.authenticate('jwt', { session: false }), (req, res, next) =>
-  memberController.deleteSns(req, res, next)
-);
-
-router.get('/:memberId/sns', passport.authenticate('jwt', { session: false }), (req, res, next) =>
-  memberController.getSnsList(req, res, next)
-);
-
-router.post('/follows/:memberId', passport.authenticate('jwt', { session: false }), (req, res, next) =>
-  memberController.followUser(req, res, next)
-);
-
-router.delete('/follows/:memberId', passport.authenticate('jwt', { session: false }), (req, res, next) =>
-  memberController.unfollowUser(req, res, next)
+router.delete(
+  '/unfollow/:memberId',
+  authenticateJwt,
+  memberController.unfollowUser.bind(memberController),
 );
 
 export default router; 

--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -51,4 +51,22 @@ export class MemberService {
       updated_at: f.updated_at,
     }));
   }
+
+  async getFollowings(memberId: number) {
+    const user = await this.memberRepository.findUserById(memberId);
+    if (!user) {
+      throw new AppError('NotFound', '해당 사용자를 찾을 수 없습니다.', 404);
+    }
+
+    const followings = await this.memberRepository.findFollowingsByMemberId(memberId);
+
+    return followings.map((f) => ({
+      follow_id: f.follow_id,
+      following_id: f.following_id,
+      nickname: f.following.nickname,
+      email: f.following.email,
+      created_at: f.created_at,
+      updated_at: f.updated_at,
+    }));
+  }
 } 


### PR DESCRIPTION
## 📌 기능 설명
회원의 팔로워 및 팔로잉 목록을 조회하는 API 기능을 구현했습니다. 이를 통해 특정 사용자의 소셜 관계를 확인할 수 있습니다.

## 📌 구현 내용
### 1. 팔로워 목록 조회 API
- **`GET /api/members/followers/{member-id}`**
- `MemberRepository`에 `findFollowersByMemberId` 메서드를 추가하여 특정 사용자를 팔로우하는 사용자 목록을 데이터베이스에서 조회합니다.
- `MemberService`에 `getFollowers` 메서드를 추가하여 관련 비즈니스 로직을 처리합니다.
- `MemberController`에 `getFollowers` 메서드를 추가하여 HTTP 요청을 처리하도록 구현했습니다.

### 2. 팔로잉 목록 조회 API
- **`GET /api/members/following/{member-id}`**
- `MemberRepository`에 `findFollowingsByMemberId` 메서드를 추가하여 특정 사용자가 팔로우하는 사용자 목록을 조회합니다.
- `MemberService`와 `MemberController`에 각각 `getFollowings` 메서드를 추가하여 비즈니스 로직과 요청을 처리합니다.

### 3. 라우팅 및 공통 로직
- 기존 `tsoa` 자동 생성 방식 대신, `express.Router`를 사용하는 수동 라우팅 방식으로 `src/members/routes/member.route.ts` 파일에 라우트를 설정했습니다.
- `passport-jwt`를 사용하여 모든 API에 대한 인증을 적용했습니다.
- API 응답 DTO(`FollowerDto`)를 정의하여 일관된 데이터 형식을 제공합니다.

## 📌 구현 결과
- API 요청 시 지정된 사용자의 팔로워 또는 팔로잉 목록이 명세에 따라 정상적으로 반환됩니다.
- 로그인하지 않은 사용자가 API를 호출하면 `401 Unauthorized` 에러가 발생합니다.
- 존재하지 않는 사용자 ID로 요청 시 `404 Not Found` 에러가 반환됩니다.

**API Response Example (`GET /api/members/followers/{member-id}`)**
<img width="965" height="711" alt="image" src="https://github.com/user-attachments/assets/32b6109f-e744-495c-9301-1ce82c1ef8d9" />

**API Response Example (`GET /api/members/following/{member-id}`)**
<img width="968" height="744" alt="image" src="https://github.com/user-attachments/assets/125e616c-f5c1-404d-90e8-005d32f3fc42" />


## 📌 논의하고 싶은 점
- 현재 팔로워/팔로잉 목록 조회 시 응답 데이터에 `email` 정보가 포함되어 있습니다. 개인정보 보호 측면에서 이메일 대신 `nickname`, `profileImage` 등 공개 가능한 정보만 반환하는 것이 어떨지 논의가 필요해 보입니다.