### PR TITLE
feat: 특정 유저 프롬프트 목록 불러오기 기능 추가 (#71)

### DIFF
--- a/src/members/controllers/member.controller.ts
+++ b/src/members/controllers/member.controller.ts
@@ -58,4 +58,58 @@ export class MemberController {
       next(error);
     }
   }
+
+  public async getMemberPrompts(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const { memberId } = req.params;
+      const { cursor, limit } = req.query;
+      
+      // memberId 검증
+      const memberIdNum = parseInt(memberId, 10);
+      
+      // 쿼리 파라미터 검증
+      const cursorNum = cursor ? parseInt(cursor as string, 10) : undefined;
+      const limitNum = limit ? parseInt(limit as string, 10) : 10; // 기본값 10
+      
+      
+      if (limit && (isNaN(limitNum) || limitNum <= 0 || limitNum > 50)) {
+        res.status(400).json({
+          error: 'BadRequest',
+          message: 'limit은 1-50 사이의 숫자여야 합니다.',
+          statusCode: 400,
+        });
+        return;
+      }
+
+      const result = await this.memberService.getMemberPrompts(memberIdNum, cursorNum, limitNum);
+      
+      res.status(200).json({
+        message: '회원 프롬프트 목록 조회 완료',
+        data: {
+          prompts: result.prompts,
+          pagination: {
+            nextCursor: result.nextCursor,
+            has_more: result.has_more,
+            limit: limitNum
+          }
+        },
+        statusCode: 200,
+      });
+    } catch (error) {
+      // 에러 예외 처리
+      if (error instanceof Error) {
+        res.status(500).json({
+          error: 'InternalServerError',
+          message: error.message,
+          statusCode: 500,
+        });
+      } else {
+        res.status(500).json({
+          error: 'InternalServerError',
+          message: '알 수 없는 오류가 발생했습니다.',
+          statusCode: 500,
+        });
+      }
+    }
+  }
 } 

--- a/src/members/dtos/member-prompts.dto.ts
+++ b/src/members/dtos/member-prompts.dto.ts
@@ -1,0 +1,28 @@
+export interface MemberPromptDto {
+  prompt_id: number;
+  title: string;
+  models: {
+    model: {
+      name: string;
+    };
+  }[];
+  tags: {
+    tag: {
+      name: string;
+    };
+  }[];
+}
+
+export interface MemberPromptQueryDto {
+  cursor?: string; // 마지막으로 받은 prompt_id
+  limit?: string; // 한 번에 가져올 개수 (기본: 10)
+}
+
+export interface MemberPromptResponseDto {
+  prompts: MemberPromptDto[];
+  pagination: {
+    nextCursor: number | null; // 다음 페이지의 커서
+    has_more: boolean; // 다음 페이지 존재 여부
+    limit: number; // 현재 페이지 크기
+  };
+} 

--- a/src/members/routes/member.route.ts
+++ b/src/members/routes/member.route.ts
@@ -27,4 +27,7 @@ router.get(
   memberController.getFollowings.bind(memberController),
 );
 
+// 특정 회원의 프롬프트 목록 조회 API
+router.get('/:memberId/prompts', memberController.getMemberPrompts.bind(memberController));
+
 export default router; 

--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -1,6 +1,7 @@
 import { MemberRepository } from '../repositories/member.repository';
 import { AppError } from '../../errors/AppError';
 import { Service } from 'typedi';
+import { getMemberPromptsRepo } from '../repositories/member.repository';
 
 @Service()
 export class MemberService {
@@ -68,5 +69,12 @@ export class MemberService {
       created_at: f.created_at,
       updated_at: f.updated_at,
     }));
+  }
+
+  async getMemberPrompts(memberId: number, cursor?: number, limit?: number) {
+    const DEFAULT_LIMIT = 10;
+    const actualLimit = limit && limit > 0 && limit <= 50 ? limit : DEFAULT_LIMIT;
+    
+    return await getMemberPromptsRepo(memberId, cursor, actualLimit);
   }
 } 


### PR DESCRIPTION
## 📌 기능 설명
특정 유저의 프롬프트 목록을 불러옵니다.

## 📌 구현 내용
특정 유저가 작성한 프롬프트 목록을 불러옵니다
커서 페이징을 구현했습니다

## 📌 구현 결과
<img width="685" height="690" alt="스크린샷 2025-07-27 오전 4 18 39" src="https://github.com/user-attachments/assets/a836bc67-4f23-40b0-a44d-873b9ad9dcd4" />


## 📌 논의하고 싶은 점
피그마 6-1 타인이 작성한 프롬프트 와 7-1 내가 작성한 프롬프트일때 불러오는 항목이 같아서 API 구분을 하지 않았는데 구분을 하는게 더 나을지 고민이 됩니다.