### PR TITLE
feat: 문의하기 구현

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import ReviewRouter from './reviews/routes/review.route';
 import promptDownloadRouter from './prompts/routes/prompt.downlaod.route';
 import promptLikeRouter from './prompts/routes/prompt.like.route';
 import tipRouter from "./tip/routes/tip.route"; // 팁 라우터 import
+import inquiryRouter from './inquiries/routes/inquiry.route';
 // import * as swaggerDocument from './docs/swagger/swagger.json';
 // import { RegisterRoutes } from './routes/routes'; // tsoa가 생성하는 파일
 
@@ -65,6 +66,9 @@ app.use("/api/prompts", promptLikeRouter);
 
 // 팁 라우터
 app.use("/api/tips", tipRouter);
+
+// 문의 라우터
+app.use('/api/inquiries', inquiryRouter);
 
 // 예시 라우터
 app.get("/", (req, res) => {

--- a/src/inquiries/controllers/inquiry.controller.ts
+++ b/src/inquiries/controllers/inquiry.controller.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction } from 'express';
+import { InquiryService } from '../services/inquiry.service';
+import { InquiryRepository } from '../repositories/inquiry.repository';
+import { MemberRepository } from '../../members/repositories/member.repository';
+import { CreateInquiryDto } from '../dtos/create-inquiry.dto';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { AppError } from '../../errors/AppError';
+
+export class InquiryController {
+  private inquiryService: InquiryService;
+
+  constructor() {
+    this.inquiryService = new InquiryService(new InquiryRepository(), new MemberRepository());
+  }
+
+  public async createInquiry(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const senderId = (req.user as any).user_id;
+      const createInquiryDto = plainToInstance(CreateInquiryDto, req.body);
+      const errors = await validate(createInquiryDto);
+
+      if (errors.length > 0) {
+        const message = errors.map((error) => Object.values(error.constraints || {})).join(', ');
+        throw new AppError('BadRequest', message, 400);
+      }
+
+      const inquiry = await this.inquiryService.createInquiry(senderId, createInquiryDto);
+
+      res.status(201).json({
+        message: '문의가 등록되었습니다.',
+        data: inquiry,
+        statusCode: 201,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+} 

--- a/src/inquiries/dtos/create-inquiry.dto.ts
+++ b/src/inquiries/dtos/create-inquiry.dto.ts
@@ -1,0 +1,20 @@
+import { IsEnum, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { InquiryType } from '@prisma/client';
+
+export class CreateInquiryDto {
+  @IsNumber()
+  @IsNotEmpty()
+  receiver_id: number;
+
+  @IsEnum(InquiryType)
+  @IsNotEmpty()
+  type: InquiryType;
+
+  @IsString()
+  @IsNotEmpty({ message: '제목은 필수 입력 항목입니다.' })
+  title: string;
+
+  @IsString()
+  @IsNotEmpty({ message: '내용은 필수 입력 항목입니다.' })
+  content: string;
+} 

--- a/src/inquiries/repositories/inquiry.repository.ts
+++ b/src/inquiries/repositories/inquiry.repository.ts
@@ -1,0 +1,19 @@
+import { Service } from 'typedi';
+import prisma from '../../config/prisma';
+import { CreateInquiryDto } from '../dtos/create-inquiry.dto';
+
+@Service()
+export class InquiryRepository {
+  async createInquiry(senderId: number, createInquiryDto: CreateInquiryDto) {
+    return prisma.inquiry.create({
+      data: {
+        sender_id: senderId,
+        receiver_id: createInquiryDto.receiver_id,
+        type: createInquiryDto.type,
+        status: 'waiting',
+        title: createInquiryDto.title,
+        content: createInquiryDto.content,
+      },
+    });
+  }
+} 

--- a/src/inquiries/routes/inquiry.route.ts
+++ b/src/inquiries/routes/inquiry.route.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { InquiryController } from '../controllers/inquiry.controller';
+import { authenticateJwt } from '../../config/passport';
+
+const router = Router();
+const inquiryController = new InquiryController();
+
+router.post(
+  '/',
+  authenticateJwt,
+  inquiryController.createInquiry.bind(inquiryController),
+);
+
+export default router; 

--- a/src/inquiries/services/inquiry.service.ts
+++ b/src/inquiries/services/inquiry.service.ts
@@ -1,0 +1,22 @@
+import { Service } from 'typedi';
+import { InquiryRepository } from '../repositories/inquiry.repository';
+import { MemberRepository } from '../../members/repositories/member.repository';
+import { CreateInquiryDto } from '../dtos/create-inquiry.dto';
+import { AppError } from '../../errors/AppError';
+
+@Service()
+export class InquiryService {
+  constructor(
+    private inquiryRepository: InquiryRepository,
+    private memberRepository: MemberRepository,
+  ) {}
+
+  async createInquiry(senderId: number, createInquiryDto: CreateInquiryDto) {
+    const receiver = await this.memberRepository.findUserById(createInquiryDto.receiver_id);
+    if (!receiver) {
+      throw new AppError('NotFound', '해당 수신자를 찾을 수 없습니다.', 404);
+    }
+
+    return this.inquiryRepository.createInquiry(senderId, createInquiryDto);
+  }
+} 


### PR DESCRIPTION
## 📌 기능 설명
사용자가 다른 사용자에게 문의를 보낼 수 있는 '문의하기' API 기능을 구현했습니다.

## 📌 구현 내용
- **`POST /api/inquiries`**: 인증된 사용자가 다른 사용자에게 문의를 등록하는 API입니다.
- **`inquiries` 모듈 신규 생성**: 문의 기능을 관리하기 위해 `controllers`, `dtos`, `repositories`, `routes`, `services` 디렉토리 및 관련 파일을 새로 생성했습니다.
- **DTO 유효성 검사**: `class-validator`를 사용하여 요청 본문(`receiver_id`, `type`, `title`, `content`)의 유효성을 검사하도록 구현했습니다. 필수 값이 누락될 경우 `400 Bad Request` 에러를 반환합니다.
- **수신자 존재 여부 확인**: 문의를 생성하기 전, `MemberRepository`를 통해 문의를 받는 사용자(receiver)가 실제로 존재하는지 확인하는 로직을 서비스 레이어에 추가했습니다. 수신자가 존재하지 않으면 `404 Not Found` 에러를 반환합니다.
- **라우팅 설정**: `express.Router`를 사용하여 `inquiry.route.ts` 파일에 라우트를 설정하고, `passport-jwt`를 이용한 인증 미들웨어를 적용했습니다.

## 📌 구현 결과
- `POST /api/inquiries` API 요청 시, 명세에 따라 문의가 성공적으로 등록되고 `201 Created` 상태 코드와 함께 생성된 문의 정보를 반환합니다.

**API Response Example (`POST /api/inquiries`)**
<img width="968" height="739" alt="image" src="https://github.com/user-attachments/assets/7c712c69-3e9f-4349-8942-b8da3151e376" />


## 📌 논의하고 싶은 점