### PR TITLE
refactor: accessToken 유효시간 1h -> 3h

### DIFF
--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -9,7 +9,7 @@ interface Tokens {
 class AuthService {
   async generateTokens(user: any): Promise<Tokens> {
     const accessToken = jwt.sign({ id: user.user_id }, process.env.JWT_SECRET!, {
-      expiresIn: '1h',
+      expiresIn: '3h',
     });
     const refreshToken = jwt.sign({ id: user.user_id }, process.env.JWT_SECRET!, {
       expiresIn: '14d',


### PR DESCRIPTION
## 📌 기능 설명
사용자 편의성 향상을 위해 Access Token의 유효 기간을 기존 1시간에서 3시간으로 연장했습니다.

## 📌 구현 내용
- **`src/auth/services/auth.service.ts`** 파일의 `generateTokens` 메서드를 수정했습니다.
- `accessToken`을 생성하는 `jwt.sign` 함수의 `expiresIn` 옵션 값을 `'1h'`에서 `'3h'`로 변경했습니다.

```typescript
// src/auth/services/auth.service.ts

// 수정 전
const accessToken = jwt.sign({ id: user.user_id }, process.env.JWT_SECRET!, {
  expiresIn: '1h',
});

// 수정 후
const accessToken = jwt.sign({ id: user.user_id }, process.env.JWT_SECRET!, {
  expiresIn: '3h',
});
```

## 📌 구현 결과
- 이 변경으로 인해 사용자는 한 번 로그인하면 3시간 동안 세션이 유지됩니다.
- 사용자가 더 오랜 시간 동안 로그인 상태를 유지할 수 있게 되어, 잦은 재로그인으로 인한 불편함이 감소합니다.

## 📌 논의하고 싶은 점