### PR TITLE
feat: 사용자 문의 목록 조회

### DIFF
--- a/src/inquiries/controllers/inquiry.controller.ts
+++ b/src/inquiries/controllers/inquiry.controller.ts
@@ -6,6 +6,7 @@ import { CreateInquiryDto } from '../dtos/create-inquiry.dto';
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import { AppError } from '../../errors/AppError';
+import { GetInquiriesDto } from '../dtos/get-inquiries.dto';
 
 export class InquiryController {
   private inquiryService: InquiryService;
@@ -31,6 +32,29 @@ export class InquiryController {
         message: '문의가 등록되었습니다.',
         data: inquiry,
         statusCode: 201,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getReceivedInquiries(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const receiverId = (req.user as any).user_id;
+      const getInquiriesDto = plainToInstance(GetInquiriesDto, req.query);
+      const errors = await validate(getInquiriesDto);
+
+      if (errors.length > 0) {
+        const message = errors.map((error) => Object.values(error.constraints || {})).join(', ');
+        throw new AppError('BadRequest', message, 400);
+      }
+
+      const inquiries = await this.inquiryService.getReceivedInquiries(receiverId, getInquiriesDto.type);
+
+      res.status(200).json({
+        message: '받은 문의 목록 조회 완료',
+        data: inquiries,
+        statusCode: 200,
       });
     } catch (error) {
       next(error);

--- a/src/inquiries/dtos/get-inquiries.dto.ts
+++ b/src/inquiries/dtos/get-inquiries.dto.ts
@@ -1,0 +1,8 @@
+import { IsEnum, IsOptional } from 'class-validator';
+import { InquiryType } from '@prisma/client';
+
+export class GetInquiriesDto {
+  @IsOptional()
+  @IsEnum(InquiryType, { message: 'type은 buyer 또는 non_buyer만 가능합니다.' })
+  type?: InquiryType;
+} 

--- a/src/inquiries/repositories/inquiry.repository.ts
+++ b/src/inquiries/repositories/inquiry.repository.ts
@@ -16,4 +16,30 @@ export class InquiryRepository {
       },
     });
   }
+
+  async findReceivedInquiries(receiverId: number, type?: 'buyer' | 'non_buyer') {
+    return prisma.inquiry.findMany({
+      where: {
+        receiver_id: receiverId,
+        ...(type && { type }),
+      },
+      select: {
+        inquiry_id: true,
+        sender_id: true,
+        sender: {
+          select: {
+            nickname: true,
+          },
+        },
+        type: true,
+        status: true,
+        title: true,
+        created_at: true,
+        updated_at: true,
+      },
+      orderBy: {
+        created_at: 'desc',
+      },
+    });
+  }
 } 

--- a/src/inquiries/routes/inquiry.route.ts
+++ b/src/inquiries/routes/inquiry.route.ts
@@ -11,4 +11,10 @@ router.post(
   inquiryController.createInquiry.bind(inquiryController),
 );
 
+router.get(
+  '/received',
+  authenticateJwt,
+  inquiryController.getReceivedInquiries.bind(inquiryController),
+);
+
 export default router; 

--- a/src/inquiries/services/inquiry.service.ts
+++ b/src/inquiries/services/inquiry.service.ts
@@ -19,4 +19,19 @@ export class InquiryService {
 
     return this.inquiryRepository.createInquiry(senderId, createInquiryDto);
   }
+
+  async getReceivedInquiries(receiverId: number, type?: 'buyer' | 'non_buyer') {
+    const inquiries = await this.inquiryRepository.findReceivedInquiries(receiverId, type);
+
+    return inquiries.map((inquiry) => ({
+      inquiry_id: inquiry.inquiry_id,
+      sender_id: inquiry.sender_id,
+      sender_nickname: inquiry.sender.nickname,
+      type: inquiry.type,
+      status: inquiry.status,
+      title: inquiry.title,
+      created_at: inquiry.created_at,
+      updated_at: inquiry.updated_at,
+    }));
+  }
 } 


### PR DESCRIPTION
## 📌 기능 설명
사용자가 자신에게 온 문의 목록을 조회할 수 있는 API 기능을 구현했습니다. 이를 통해 사용자는 문의를 효율적으로 확인하고 관리할 수 있습니다.

## 📌 구현 내용
- **API 엔드포인트 추가**: `GET /api/inquiries/received`
  - 사용자는 `Authorization` 헤더의 토큰을 통해 자신을 인증하고, 본인이 받은 모든 문의 목록을 조회할 수 있습니다.
  - **쿼리 파라미터를 통해 문의 유형(`buyer` 또는 `non_buyer`)에 따라 필터링이 가능합니다. (`e.g., GET /api/inquiries/received?type=buyer`)**

- **DTO 추가**: `src/inquiries/dtos/get-inquiries.dto.ts`
  - `type` 쿼리 파라미터의 유효성을 검사하기 위한 `GetInquiriesDto`를 추가했습니다.
  - `@IsOptional`과 `@IsEnum`을 사용하여 `type`이 선택 사항이며, 정해진 값(`buyer`, `non_buyer`)만 받도록 설정했습니다.

- **계층별 로직 구현**:
  - **`InquiryRepository`**: `findReceivedInquiries` 메서드를 추가하여, `receiver_id`를 기준으로 문의를 조회하고 보낸 사람(`sender`)의 닉네임 정보를 함께 가져오도록 구현했습니다.
  - **`InquiryService`**: `getReceivedInquiries` 메서드를 추가하여, 리포지토리에서 받은 데이터를 최종 응답 형식에 맞게 가공합니다.
  - **`InquiryController`**: `getReceivedInquiries` 메서드를 추가하여, HTTP 요청을 처리하고 쿼리 파라미터 유효성 검사를 수행한 후 서비스 로직을 호출합니다.

## 📌 구현 결과
- API 요청 시, 인증된 사용자가 받은 문의 목록이 명세에 따라 최신순으로 정렬되어 정상적으로 반환됩니다.

**API Response Example (`GET /api/inquiries/received`)**
<img width="968" height="749" alt="image" src="https://github.com/user-attachments/assets/9049a30a-2234-4117-9e86-bfe8ca65ce43" />

**API Response Example (`GET /api/inquiries/received?type=buyer`)**
<img width="971" height="610" alt="image" src="https://github.com/user-attachments/assets/19bc63b7-bf90-4d36-9d1a-eba7c35b98f4" />

**API Response Example (`GET /api/inquiries/received?type=non_buyer`)**
<img width="964" height="574" alt="image" src="https://github.com/user-attachments/assets/1dff8d31-8231-4d90-bb58-d18a9fce7d44" />


## 📌 논의하고 싶은 점