### PR TITLE
feat: 관리자 리뷰 삭제 조치(#82)

### DIFF
--- a/src/reviews/repositories/review.repository.ts
+++ b/src/reviews/repositories/review.repository.ts
@@ -208,3 +208,12 @@ export const findAllMyReviewsByUserId = async (
     }
   });
 };
+
+// 사용자 ID로 사용자 정보 조회
+export const findUserById = async (userId: number) => {
+  return await prisma.user.findUnique({
+    where: {
+      user_id: userId
+    }
+  });
+};

--- a/src/reviews/routes/review.route.ts
+++ b/src/reviews/routes/review.route.ts
@@ -16,7 +16,7 @@ router.get('/me', authenticateJwt, getReviewsWrittenByMe); // 내가 작성한 �
 router.get('/received-reviews/me', authenticateJwt, getMyReceivedReviews); // 내가 받은 리뷰 목록 조회
 router.get('/:promptId', authenticateJwt, getReviewsByPromptId); // 특정 프롬프트 리뷰 목록 조회
 router.post('/:promptId', authenticateJwt, postReview); // 특정 프롬프트에 대한 리뷰 작성
-router.delete('/:reviewId', authenticateJwt, deleteReview);
+router.delete('/:reviewId', authenticateJwt, deleteReview); // 리뷰 삭제
 router.get('/:reviewId/edit', authenticateJwt, getReviewEditData);
 router.patch('/:reviewId', authenticateJwt, editReview);
 


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
관리자 페이지에서 리뷰 삭제 조치를 할 수 있는 기능

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
관리자는 아무 제약 없이 사람들이 작성한 리뷰를 삭제할 수 있습니다. 이전에 작성했던 리뷰 삭제 api는 일반 user 대상이었기 때문에 service 계층에서 user와 admin을 구분하여 각 기능을  수행하도록 처리했습니다. 


<일반 user일 경우>
- 작성일로부터 30일이 지나면 삭제 불가능
- 자신이 작성한 리뷰만 삭제 가능

<admin일 경우>
- 제약 없이 모든 리뷰 삭제 가능


## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
- admin 계정일 때
<img width="2417" height="470" alt="image" src="https://github.com/user-attachments/assets/263fee56-862b-4120-9981-b3f13527d3bf" />

- user 계정일 때 사용자가 작성하지 않은 리뷰를  삭제하려고 할 때 에러처리
<img width="1261" height="198" alt="image" src="https://github.com/user-attachments/assets/f575e003-aa02-4505-9837-c167b8608650" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->