### PR TITLE
Chore: 프론트엔드 CORS 허용

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/passport-google-oauth20": "^2.0.16",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "cors": "^2.8.5",
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
     "express-session": "^1.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       class-validator:
         specifier: ^0.14.2
         version: 0.14.2
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
       dotenv:
         specifier: ^17.0.1
         version: 17.2.0
@@ -951,6 +954,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -3288,6 +3295,11 @@ snapshots:
   cookie@0.7.1: {}
 
   cookie@0.7.2: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   create-require@1.1.1: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { errorHandler } from "./middlewares/errorHandler";
 import passport from './config/passport';
 import swaggerUi from 'swagger-ui-express';
 import session from 'express-session';
+import cors from "cors";
 import authRouter from './auth/routes/auth.route'; // auth 라우터 경로 수정
 import membersRouter from './members/routes/member.route'; // members 라우터 import
 import promptRoutes from './prompts/routes/prompt.route'; // 프롬프트 관련 라우터
@@ -19,6 +20,14 @@ import inquiryRouter from './inquiries/routes/inquiry.route';
 
 const app = express();
 app.use(express.json());
+
+// CORS 설정
+const allowedOrigins = ['https://promptplace-fe.vercel.app'];
+
+app.use(cors({
+  origin: allowedOrigins,
+  credentials: true, // 세션 쿠키 등 인증 정보 주고받을 경우 true
+}));
 
 app.use(responseHandler);
 


### PR DESCRIPTION
## 📌 기능 설명
백엔드 API에서 프론트엔드(Vercel에 배포된 도메인)의 요청을 허용하도록 CORS 설정을 추가했습니다.

## 📌 구현 내용
- [ ] cors 패키지 설치 및 적용
- [ ] https://promptplace-fe.vercel.app 도메인에서 오는 요청을 허용
- [ ] 세션 기반 인증을 위해 credentials: true 옵션 추가

## 📌 구현 결과
app.use(cors({
  origin: ['https://promptplace-fe.vercel.app'],
  credentials: true,
}));

## 📌 논의하고 싶은 점