### PR TITLE
fix: 프로필 이미지 url 참조 테이블 변경

### DIFF
--- a/src/reviews/repositories/review.repository.ts
+++ b/src/reviews/repositories/review.repository.ts
@@ -48,7 +48,7 @@ export const findUserProfilesByUserIds = async (userIds: number[]) => {
     select: {
       user_id: true,
       nickname: true,
-      profileImage: {
+      profileImage: { 
         select: {
           url: true
         }


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
리뷰 목록 조회 api에서 UserProfile을 참조한 기존 버전에서 UserImage로 변환

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
Review.repository
- findUserProfilesByUserIds함수에서 user과 조인하는 모델명을 profileImage로 변경

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
<img width="2206" height="1026" alt="스크린샷 2025-07-29 175644" src="https://github.com/user-attachments/assets/2afd6a73-a345-448b-bf74-b9b863e3e08f" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->