### PR TITLE
[FEAT] 문의 답변하기, 문의 읽음 처리

### DIFF
--- a/src/inquiries/controllers/inquiry.controller.ts
+++ b/src/inquiries/controllers/inquiry.controller.ts
@@ -7,6 +7,7 @@ import { plainToInstance } from "class-transformer";
 import { validate } from "class-validator";
 import { AppError } from "../../errors/AppError";
 import { GetInquiriesDto } from "../dtos/get-inquiries.dto";
+import { CreateReplyDto } from "../dtos/create-reply.dto";
 
 export class InquiryController {
   private inquiryService: InquiryService;
@@ -100,6 +101,40 @@ export class InquiryController {
         message: "받은 문의 목록 조회 완료",
         data: inquiries,
         statusCode: 200,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async createInquiryReply(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const userId = (req.user as any).user_id;
+      const inquiryId = parseInt(req.params.inquiryId, 10);
+
+      const dto = plainToInstance(CreateReplyDto, req.body);
+      const errors = await validate(dto);
+      if (errors.length > 0) {
+        const message = errors
+          .map((error) => Object.values(error.constraints!))
+          .join(", ");
+        throw new AppError("BadRequest", message, 400);
+      }
+
+      const reply = await this.inquiryService.createInquiryReply(
+        userId,
+        inquiryId,
+        dto.content
+      );
+
+      res.status(201).json({
+        message: "문의 답변이 등록되었습니다.",
+        data: reply,
+        statusCode: 201,
       });
     } catch (error) {
       next(error);

--- a/src/inquiries/controllers/inquiry.controller.ts
+++ b/src/inquiries/controllers/inquiry.controller.ts
@@ -140,4 +140,28 @@ export class InquiryController {
       next(error);
     }
   }
+
+  public async markInquiryAsRead(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const userId = (req.user as any).user_id;
+      const inquiryId = parseInt(req.params.inquiryId, 10);
+
+      const updatedInquiry = await this.inquiryService.markInquiryAsRead(
+        userId,
+        inquiryId
+      );
+
+      res.status(200).json({
+        message: "문의가 읽음 처리되었습니다.",
+        data: updatedInquiry,
+        statusCode: 200,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/src/inquiries/dtos/create-reply.dto.ts
+++ b/src/inquiries/dtos/create-reply.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class CreateReplyDto {
+  @IsString()
+  @IsNotEmpty({ message: "답변 내용은 필수 입력 항목입니다." })
+  content!: string;
+}

--- a/src/inquiries/repositories/inquiry.repository.ts
+++ b/src/inquiries/repositories/inquiry.repository.ts
@@ -47,6 +47,18 @@ export class InquiryRepository {
     });
   }
 
+  async updateInquiryStatus(inquiryId: number, status: "waiting" | "read") {
+    return prisma.inquiry.update({
+      where: { inquiry_id: inquiryId },
+      data: { status: status },
+      select: {
+        inquiry_id: true,
+        status: true,
+        updated_at: true,
+      },
+    });
+  }
+
   async findReceivedInquiries(
     receiverId: number,
     type?: "buyer" | "non_buyer"

--- a/src/inquiries/repositories/inquiry.repository.ts
+++ b/src/inquiries/repositories/inquiry.repository.ts
@@ -37,6 +37,16 @@ export class InquiryRepository {
     });
   }
 
+  async createInquiryReply(inquiryId: number, userId: number, content: string) {
+    return prisma.inquiryReply.create({
+      data: {
+        inquiry_id: inquiryId,
+        receiver_id: userId, // 스키마에 따라 답변자를 receiver_id에 저장
+        content: content,
+      },
+    });
+  }
+
   async findReceivedInquiries(
     receiverId: number,
     type?: "buyer" | "non_buyer"

--- a/src/inquiries/routes/inquiry.route.ts
+++ b/src/inquiries/routes/inquiry.route.ts
@@ -23,4 +23,11 @@ router.get(
   inquiryController.getInquiryById.bind(inquiryController)
 );
 
+// 문의 답변 등록 API
+router.post(
+  "/:inquiryId/replies",
+  authenticateJwt,
+  inquiryController.createInquiryReply.bind(inquiryController)
+);
+
 export default router;

--- a/src/inquiries/routes/inquiry.route.ts
+++ b/src/inquiries/routes/inquiry.route.ts
@@ -30,4 +30,11 @@ router.post(
   inquiryController.createInquiryReply.bind(inquiryController)
 );
 
+// 문의 읽음 처리 API
+router.patch(
+  "/:inquiryId/read",
+  authenticateJwt,
+  inquiryController.markInquiryAsRead.bind(inquiryController)
+);
+
 export default router;

--- a/src/inquiries/services/inquiry.service.ts
+++ b/src/inquiries/services/inquiry.service.ts
@@ -76,6 +76,26 @@ export class InquiryService {
     );
   }
 
+  async markInquiryAsRead(userId: number, inquiryId: number) {
+    // 1. 문의 존재 여부 확인
+    const inquiry = await this.inquiryRepository.findInquiryById(inquiryId);
+    if (!inquiry) {
+      throw new AppError("NotFound", "해당 문의를 찾을 수 없습니다.", 404);
+    }
+
+    // 2. 읽음 처리 권한 확인 (문의의 수신자인지)
+    if (inquiry.receiver_id !== userId) {
+      throw new AppError(
+        "Forbidden",
+        "해당 문의를 읽음 처리할 권한이 없습니다.",
+        403
+      );
+    }
+
+    // 3. 문의 상태 변경
+    return this.inquiryRepository.updateInquiryStatus(inquiryId, "read");
+  }
+
   async getReceivedInquiries(receiverId: number, type?: "buyer" | "non_buyer") {
     const inquiries = await this.inquiryRepository.findReceivedInquiries(
       receiverId,

--- a/src/inquiries/services/inquiry.service.ts
+++ b/src/inquiries/services/inquiry.service.ts
@@ -52,6 +52,30 @@ export class InquiryService {
     };
   }
 
+  async createInquiryReply(userId: number, inquiryId: number, content: string) {
+    // 1. 문의 존재 여부 확인
+    const inquiry = await this.inquiryRepository.findInquiryById(inquiryId);
+    if (!inquiry) {
+      throw new AppError("NotFound", "해당 문의를 찾을 수 없습니다.", 404);
+    }
+
+    // 2. 답변 권한 확인 (문의의 수신자인지)
+    if (inquiry.receiver_id !== userId) {
+      throw new AppError(
+        "Forbidden",
+        "해당 문의에 답변할 권한이 없습니다.",
+        403
+      );
+    }
+
+    // 3. 답변 생성
+    return this.inquiryRepository.createInquiryReply(
+      inquiryId,
+      userId,
+      content
+    );
+  }
+
   async getReceivedInquiries(receiverId: number, type?: "buyer" | "non_buyer") {
     const inquiries = await this.inquiryRepository.findReceivedInquiries(
       receiverId,


### PR DESCRIPTION
## 📌 기능 설명
- 문의(Inquiry)에 대해 담당자(판매자)가 답변을 등록하는 기능과, 문의를 읽음 상태로 변경하는 기능을 구현했습니다.

## 📌 구현 내용
- **문의 답변 등록 (`POST /api/inquiries/{inquiry-id}/replies`)**
  - 문의를 받은 사용자가 해당 문의에 대한 답변을 등록할 수 있는 API를 구현했습니다.
  - `CreateReplyDto`를 추가하여 요청 시 답변 내용(`content`)이 비어있지 않은지 유효성을 검사합니다.
  - 서비스 로직에서 아래의 사항을 검증합니다.
    1.  요청 대상 문의의 존재 여부
    2.  답변을 등록하려는 사용자가 해당 문의의 수신자가 맞는지 권한 확인
  - 검증 완료 후, `InquiryReply` 테이블에 답변 내용을 저장하고 생성된 데이터를 반환합니다.

- **문의 읽음 처리 (`PATCH /api/inquiries/{inquiry-id}/read`)**
  - 문의를 받은 사용자가 문의의 상태를 '읽음(read)'으로 변경할 수 있는 API를 구현했습니다.
  - 서비스 로직에서 아래의 사항을 검증합니다.
    1.  요청 대상 문의의 존재 여부
    2.  상태를 변경하려는 사용자가 해당 문의의 수신자가 맞는지 권한 확인
  - 검증 완료 후, `Inquiry` 테이블의 `status`를 `read`로 업데이트하고 변경된 데이터를 반환합니다.

## 📌 구현 결과
- 백엔드 API 구현으로, Postman과 같은 API 테스트 도구를 통해 각 기능의 성공 및 에러 케이스를 확인할 수 있습니다.
- **답변 등록 성공 시**: `201 Created` 상태 코드와 함께 생성된 답변 객체가 반환됩니다.
- **읽음 처리 성공 시**: `200 OK` 상태 코드와 함께 업데이트된 문의 정보(id, status, updated_at)가 반환됩니다.

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->