### PR TITLE
feat: 프롬프트 삭제/수정 api 구현(#86)

### DIFF
--- a/src/prompts/controllers/prompt.controller.ts
+++ b/src/prompts/controllers/prompt.controller.ts
@@ -5,6 +5,7 @@ import { DEFAULT_PROMPT_SEARCH_SIZE } from "../../config/constants";
 import { errorHandler } from "../../middlewares/errorHandler";
 import { CreatePromptImageDto } from "../dtos/prompt-image.dto";
 import { CreatePromptDto } from "../dtos/create-prompt.dto";
+import { UpdatePromptDto } from '../dtos/update-prompt.dto';
 
 export const searchPrompts = async (req: Request, res: Response) => {
   try {
@@ -145,5 +146,124 @@ export const createPrompt = async (req: Request, res: Response) => {
 
     // 5. 그 외 모든 에러는 공통 핸들러로 위임
     return errorHandler(error, req, res, () => {});
+  }
+};
+
+export const updatePrompt = async (req: Request, res: Response) => {
+  try {
+    const { promptId } = req.params;
+    const promptIdNum = Number(promptId);
+    
+    if (isNaN(promptIdNum)) {
+      return res.fail({
+        statusCode: 400,
+        error: 'BadRequest',
+        message: '유효하지 않은 프롬프트 ID입니다.',
+      });
+    }
+
+    // 인증 확인
+    if (!req.user) {
+      return res.fail({
+        statusCode: 401,
+        error: 'Unauthorized',
+        message: '인증이 필요합니다.',
+      });
+    }
+    const userId = (req.user as { user_id: number }).user_id;
+
+    // 프롬프트 존재 및 권한 확인
+    const existingPrompt = await promptService.getPromptById(promptIdNum);
+    
+    if (!existingPrompt) {
+      return res.fail({
+        statusCode: 404,
+        error: 'NotFound',
+        message: '프롬프트를 찾을 수 없습니다.',
+      });
+    }
+
+    if (existingPrompt.user_id !== userId) {
+      return res.fail({
+        statusCode: 403,
+        error: 'Forbidden',
+        message: '프롬프트를 수정할 권한이 없습니다.',
+      });
+    }
+
+    const dto: UpdatePromptDto = req.body;
+    const result = await promptService.updatePrompt(promptIdNum, dto);
+    
+    return res.success(result, '프롬프트 수정 성공');
+  } catch (error) {
+    // 서비스/레포지토리 레이어에서 발생한 특정 에러 처리
+    if (error instanceof Error && error.message === '해당 모델이 존재하지 않습니다.') {
+      return res.fail({
+        statusCode: 404,
+        error: 'NotFound',
+        message: error.message,
+      });
+    }
+
+    return res.fail({
+      statusCode: 500,
+      error: 'InternalServerError',
+      message: error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.',
+    });
+  }
+};
+
+export const deletePrompt = async (req: Request, res: Response) => {
+  try {
+    const { promptId } = req.params;
+    const promptIdNum = Number(promptId);
+    
+    if (isNaN(promptIdNum)) {
+      return res.fail({
+        statusCode: 400,
+        error: 'BadRequest',
+        message: '유효하지 않은 프롬프트 ID입니다.',
+      });
+    }
+
+    // 인증 확인
+    if (!req.user) {
+      return res.fail({
+        statusCode: 401,
+        error: 'Unauthorized',
+        message: '인증이 필요합니다.',
+      });
+    }
+    
+    const userId = (req.user as { user_id: number }).user_id;
+
+    // 프롬프트 존재 및 권한 확인
+    const existingPrompt = await promptService.getPromptById(promptIdNum);
+    
+    if (!existingPrompt) {
+      return res.fail({
+        statusCode: 404,
+        error: 'NotFound',
+        message: '프롬프트를 찾을 수 없습니다.',
+      });
+    }
+
+    if (existingPrompt.user_id !== userId) {
+      return res.fail({
+        statusCode: 403,
+        error: 'Forbidden',
+        message: '프롬프트를 삭제할 권한이 없습니다.',
+      });
+    }
+
+    await promptService.deletePrompt(promptIdNum);
+    
+    return res.success(null, '프롬프트 삭제 성공');
+  } catch (error) {
+    return res.fail({
+      statusCode: 500,
+      error: 'InternalServerError',
+      message: error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.',
+    });
   }
 };

--- a/src/prompts/dtos/update-prompt.dto.ts
+++ b/src/prompts/dtos/update-prompt.dto.ts
@@ -1,0 +1,12 @@
+export interface UpdatePromptDto {
+  title?: string;
+  prompt?: string;
+  prompt_result?: string;
+  has_image?: boolean;
+  description?: string;
+  usage_guide?: string;
+  price?: number;
+  is_free?: boolean;
+  tags?: string[];
+  model?: string;
+} 

--- a/src/prompts/routes/prompt.route.ts
+++ b/src/prompts/routes/prompt.route.ts
@@ -19,4 +19,11 @@ router.post(
 
 // 프롬프트 업로드(작성) API
 router.post("/", authenticateJwt, promptController.createPrompt);
+
+// 프롬프트 수정 API
+router.patch('/:promptId', authenticateJwt, promptController.updatePrompt);
+
+// 프롬프트 삭제 API
+router.delete('/:promptId', authenticateJwt, promptController.deletePrompt);
+
 export default router;

--- a/src/prompts/services/prompt.service.ts
+++ b/src/prompts/services/prompt.service.ts
@@ -5,6 +5,7 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { CreatePromptImageDto } from "../dtos/prompt-image.dto";
 import { v4 as uuidv4 } from "uuid";
 import { CreatePromptDto } from "../dtos/create-prompt.dto";
+import { UpdatePromptDto } from '../dtos/update-prompt.dto';
 
 /**
  * 프롬프트 검색 서비스
@@ -63,4 +64,16 @@ export const createPromptWrite = async (
   dto: CreatePromptDto
 ) => {
   return await promptRepository.createPromptWriteRepo(user_id, dto);
+};
+
+export const getPromptById = async (promptId: number) => {
+  return await promptRepository.getPromptByIdRepo(promptId);
+};
+
+export const updatePrompt = async (promptId: number, dto: UpdatePromptDto) => {
+  return await promptRepository.updatePromptRepo(promptId, dto);
+};
+
+export const deletePrompt = async (promptId: number) => {
+  return await promptRepository.deletePromptRepo(promptId);
 };


### PR DESCRIPTION
## 📌 기능 설명
- 프롬프트 수정 API
프롬프트 내용, 프롬프트와 연관된 모델과 태그들을 수정합니다.

- 프롬프트 삭제 API
해당 프롬프트, 프롬프트랑 연관된 이미지매핑, 모델, 태그매핑들을 삭제합니다.

## 📌 구현 내용


## 📌 구현 결과
<img width="668" height="530" alt="스크린샷 2025-07-30 오후 6 32 42" src="https://github.com/user-attachments/assets/2daaf8ca-7471-43dc-9ac2-478ac7cba784" />
<img width="649" height="654" alt="스크린샷 2025-07-30 오후 2 53 12" src="https://github.com/user-attachments/assets/b708ed32-d7e4-4dc1-9141-0c2fc86627d0" />


## 📌 논의하고 싶은 점
프롬프트 삭제를 하드 딜리트로 구현했는데 소프트 딜리트로 전환하는게 나을까요?
결제 내역에도 남아야 할테고, 누군가 구매했는데 삭제된 프롬프트라면 돈을 지불했음에도 못보는 상황이 발생할 수도 있으니까요
DB에서는 삭제하진 않고 그냥 deleted 처리만 해서 검색결과에 안보이게 하는것은 어떤지 궁금합니다.