### PR TITLE
#110/feat 프롬프트 상세정보 조회 구현

### DIFF
--- a/src/prompts/controllers/prompt.controller.ts
+++ b/src/prompts/controllers/prompt.controller.ts
@@ -49,6 +49,27 @@ export const searchPrompts = async (req: Request, res: Response) => {
   }
 };
 
+export const getPromptDetails = async (req: Request, res: Response) => {
+  try {
+    const { promptId } = req.params;
+    const promptIdNum = Number(promptId);
+    if (isNaN(promptIdNum)) {
+      return res.status(400).json({ message: "유효하지 않은 프롬프트 ID입니다." });
+    } 
+    const promptDetails = await promptService.getPromptDetail(promptIdNum);
+    if (!promptDetails) {
+      return res.status(404).json({ message: "해당 프롬프트를 찾을 수 없습니다." });
+    }
+    return res.status(200).json({
+      statusCode: 200,
+      message: "프롬프트 상세 조회 성공",
+      data: promptDetails,
+    });
+  } catch (error) {
+    return errorHandler(error, req, res, () => {});
+  }
+}
+
 export const presignUrl = async (req: Request, res: Response) => {
   try {
     const { key, contentType } = req.body;

--- a/src/prompts/repositories/prompt.repository.ts
+++ b/src/prompts/repositories/prompt.repository.ts
@@ -64,6 +64,99 @@ export const searchPromptRepo = async (data: SearchPromptDto) => {
   return results;
 };
 
+
+export const getPromptDetailRepo = async (promptId: number) => {
+  const prompt = await prisma.prompt.findUnique({
+    where: { prompt_id: promptId },
+    include: {
+      user: {
+        select: {
+          user_id: true,
+          nickname: true,
+          profileImage: {
+            select: { url: true },
+          },
+        },
+      },
+      models: {
+        include: {
+          model: {
+            select: { name: true },
+          },
+        },
+      },
+      tags: {
+        include: {
+          tag: {
+            select: {
+              tag_id: true,
+              name: true,
+            },
+          },
+        },
+      },
+      images: {
+        select: {
+          image_url: true,
+        },
+        orderBy: {
+          order_index: 'asc',
+        },
+      },
+    },
+  });
+
+  if (!prompt) return null;
+
+const {
+  title,
+  prompt: promptText,
+  prompt_result,
+  has_image,
+  description,
+  usage_guide,
+  price,
+  is_free,
+  models,
+  tags,
+  images,
+  user,
+} = prompt;
+
+
+return {
+  title,
+  prompt: promptText,
+  prompt_result,
+  has_image,
+  description,
+  usage_guide,
+  price,
+  is_free,
+
+  tags: tags.map(
+    ({ tag }: { tag: { tag_id: number; name: string } }) => ({
+      tag_id: tag.tag_id,
+      name: tag.name,
+    })
+  ),
+
+  models: models.map(
+    ({ model }: { model: { name: string } }) => model.name
+  ),
+
+  images: images.map(
+    ({ image_url }: { image_url: string }) => image_url
+  ),
+
+  writer: {
+    user_id: user.user_id,
+    nickname: user.nickname,
+    profile_image_url: user.profileImage?.url ?? null,
+  },
+};
+};
+
 export const createPromptWriteRepo = async (
   user_id: number,
   data: {

--- a/src/prompts/routes/prompt.route.ts
+++ b/src/prompts/routes/prompt.route.ts
@@ -7,6 +7,9 @@ const router = Router();
 // 프롬프트 검색 API
 router.get("/searches", promptController.searchPrompts);
 
+//프롬프트 상세 조회 API
+router.get("/:promptId/details", authenticateJwt, promptController.getPromptDetails);
+
 // S3 presign url 발급 API
 router.post("/presign-url", authenticateJwt, promptController.presignUrl);
 

--- a/src/prompts/services/prompt.service.ts
+++ b/src/prompts/services/prompt.service.ts
@@ -14,6 +14,11 @@ export const searchPrompts = async (dto: SearchPromptDto) => {
   return await promptRepository.searchPromptRepo(dto);
 };
 
+export const getPromptDetail = async (promptId: number) => {
+  return await promptRepository.getPromptDetailRepo(promptId);
+}
+
+
 /**
  * S3 presigned url 발급 (key는 promptimages/uuid_파일명 형식으로 강제)
  * @param key 원본 파일 경로 또는 파일명


### PR DESCRIPTION
## 📌 기능 설명
프롬프트 상세 정보를 조회하는 API를 구현하였습니다.  
사용자는 프롬프트 ID를 통해 해당 프롬프트의 상세 정보를 조회할 수 있습니다.

## 📌 구현 내용
- `GET /api/prompts/:promptId/details` 라우트 추가
- `prompt.controller.ts`에 `getPromptDetail` 핸들러 추가
- `prompt.repo.ts`에 `getPromptDetailRepo` 함수 구현
  - `Prompt` 모델 기준 `user`, `tags`, `models`, `images` 관계 포함

- 응답 데이터 구조는 다음과 같은 정보를 포함
  - `title`, `prompt`, `prompt_result`, `description`, `usage_guide`, `price`, `is_free`
  - `tags`: 태그명 배열
  - `models`: 사용된 모델명 배열
  - `images`: 프롬프트 관련 이미지 URL 배열
  - `writer`: 작성자 ID, 닉네임, 프로필 이미지 URL

## 📌 구현 결과
- 정상적으로 반환하는 모습을 보임
