### PR TITLE
[FEAT]: 새로운 팔로워 알림 생성 구현(#125)

### DIFF
--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -9,7 +9,7 @@ import { CreateHistoryDto } from "../dtos/create-history.dto";
 import { UpdateHistoryDto } from "../dtos/update-history.dto";
 import { CreateSnsDto } from "../dtos/create-sns.dto";
 import { UpdateSnsDto } from "../dtos/update-sns.dto";
-
+import eventBus from '../../config/eventBus';
 @Service()
 export class MemberService {
   constructor(private memberRepository: MemberRepository) {}
@@ -361,7 +361,12 @@ export class MemberService {
     }
 
     // 팔로우 생성
-    return this.memberRepository.createFollow(followerId, followingId);
+    const follow = await this.memberRepository.createFollow(followerId, followingId);
+
+    // 팔로우 알림 이벤트 발생
+    eventBus.emit("follow.created", followerId, followingId);
+
+    return follow;
   }
 
   async unfollowMember(followerId: number, followingId: number) {

--- a/src/notifications/listeners/notification.listener.ts
+++ b/src/notifications/listeners/notification.listener.ts
@@ -2,6 +2,7 @@ import eventBus from '../../config/eventBus';
 import { 
   createReportNotification,
   createAnnouncementNotification,
+  createFollowNotification,
 } from "../services/notification.service";
 
 
@@ -21,5 +22,14 @@ eventBus.on('announcement.created', async (announcementId: number) => {
     await createAnnouncementNotification(announcementId);
   } catch (err) {
     console.error("[알림 리스너 오류]: 공지사항 알림 생성 실패", err);
+  }
+});
+
+// 새로운 팔로워 알림 리스너
+eventBus.on('follow.created', async (followerId: number, followingId: number) => {
+  try {
+    await createFollowNotification(followerId, followingId);
+  } catch (err) {
+    console.error("[알림 리스너 오류]: 새로운 팔로워 알림 생성 실패", err);
   }
 });

--- a/src/notifications/repositories/notification.repository.ts
+++ b/src/notifications/repositories/notification.repository.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, NotificationType } from '@prisma/client';
+import { PrismaClient, NotificationType, User } from '@prisma/client';
 const prisma = new PrismaClient();
 import { CreateNotificationParams } from '../dtos/notification.dto';
 
@@ -57,6 +57,15 @@ export const deleteSubscription = async (
 }
 
 
+// 사용자 ID로 사용자 정보 조회
+export const findUserByUserId = async (userId: number):Promise<User | null> => {
+  const user = await prisma.user.findUnique({
+    where: {
+      user_id: userId
+    }
+  });
+  return user;
+};
 
 // 알림 등록 (공통)
 export const createNotification = async ({

--- a/src/notifications/services/notification.service.ts
+++ b/src/notifications/services/notification.service.ts
@@ -9,6 +9,7 @@ import {
     createSubscription,
     deleteSubscription,
     createNotification,
+    findUserByUserId,
 } from '../repositories/notification.repository';
 
 import { NotificationType } from '@prisma/client';
@@ -86,5 +87,27 @@ export const createAnnouncementNotification = async (
     content: '새로운 공지사항이 등록되었습니다.',
     linkUrl: `/announcements/${announcementId}`,
     actorId: null,
+  });
+};
+
+// 새로운 팔로워 알림
+export const createFollowNotification = async (
+  followerId: number,
+  followingId: number
+) => {
+  
+  // 팔로워 Id로 팔로워 닉네임 조회
+  const user = await findUserByUserId(followerId);
+  if (!user) {
+    throw new Error('팔로워 정보를 찾을 수 없습니다.');
+  } 
+  const followerNickname = user.nickname; 
+
+  await createNotificationService({
+    userId: followingId,
+    type: NotificationType.FOLLOW,
+    content: `'${followerNickname}'님이 회원님을 팔로우합니다.`,
+    linkUrl: `/profile/${followerId}`,
+    actorId: followerId,
   });
 };


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
사용자에게 새 팔로워가 생겼을 때 알림 생성

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
**- member.service**
   - 새 팔로워 정보를 DB에 저장하고 나서 팔로우 알림 이벤트 호출 
   
**- notification.service**
   - createFollowNotification(): 새로운 팔로워 알림 서비스 함수 등록
   
**- notification.listener**
   - 새로운 팔로워 알림 이벤트 리스너 등록 
  

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
<img width="2612" height="740" alt="스크린샷 2025-08-04 012611" src="https://github.com/user-attachments/assets/c74b746e-9dce-4fe3-875f-13006842ef9d" />


## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->