### PR TITLE
[FEAT] 새 문의 알림 생성(#127)

### DIFF
--- a/src/inquiries/services/inquiry.service.ts
+++ b/src/inquiries/services/inquiry.service.ts
@@ -3,7 +3,7 @@ import { InquiryRepository } from "../repositories/inquiry.repository";
 import { MemberRepository } from "../../members/repositories/member.repository";
 import { CreateInquiryDto } from "../dtos/create-inquiry.dto";
 import { AppError } from "../../errors/AppError";
-
+import eventBus from '../../config/eventBus';
 @Service()
 export class InquiryService {
   constructor(
@@ -18,8 +18,13 @@ export class InquiryService {
     if (!receiver) {
       throw new AppError("해당 수신자를 찾을 수 없습니다.", 404, "NotFound");
     }
+ 
+    const inquiry = await this.inquiryRepository.createInquiry(senderId, createInquiryDto);
 
-    return this.inquiryRepository.createInquiry(senderId, createInquiryDto);
+    // 새 문의 알림 이벤트 발생
+    eventBus.emit("inquiry.created", senderId, receiver.user_id);
+
+    return inquiry;
   }
 
   async getInquiryById(userId: number, inquiryId: number) {

--- a/src/notifications/listeners/notification.listener.ts
+++ b/src/notifications/listeners/notification.listener.ts
@@ -3,6 +3,7 @@ import {
   createReportNotification,
   createAnnouncementNotification,
   createFollowNotification,
+  createInquiryNotification,
 } from "../services/notification.service";
 
 
@@ -31,5 +32,14 @@ eventBus.on('follow.created', async (followerId: number, followingId: number) =>
     await createFollowNotification(followerId, followingId);
   } catch (err) {
     console.error("[알림 리스너 오류]: 새로운 팔로워 알림 생성 실패", err);
+  }
+});
+
+// 새로운 문의 등록 알림 리스너
+eventBus.on('inquiry.created', async (receiverId: number, senderId: number) => {
+  try {
+    await createInquiryNotification(receiverId, senderId);
+  } catch (err) {
+    console.error("[알림 리스너 오류]: 새로운 문의 알림 생성 실패", err);
   }
 });

--- a/src/notifications/services/notification.service.ts
+++ b/src/notifications/services/notification.service.ts
@@ -103,11 +103,26 @@ export const createFollowNotification = async (
   } 
   const followerNickname = user.nickname; 
 
+  // 팔로워 알림 정보를 알림db에 저장
   await createNotificationService({
     userId: followingId,
     type: NotificationType.FOLLOW,
     content: `'${followerNickname}'님이 회원님을 팔로우합니다.`,
     linkUrl: `/profile/${followerId}`,
     actorId: followerId,
+  });
+};
+
+// 새로운 문의 등록 알림
+export const createInquiryNotification = async (
+  receiverId: number,
+  senderId: number
+) => {
+  await createNotificationService({
+    userId: receiverId, 
+    type: NotificationType.INQUIRY,
+    content: '프롬프트에 새로운 문의가 도착했습니다.',
+    linkUrl: `/inquiries/${receiverId}`,
+    actorId: senderId,
   });
 };

--- a/src/notifications/services/notification.service.ts
+++ b/src/notifications/services/notification.service.ts
@@ -120,7 +120,7 @@ export const createInquiryNotification = async (
 ) => {
   await createNotificationService({
     userId: receiverId, 
-    type: NotificationType.INQUIRY,
+    type: NotificationType.INQUIRY_REPLY,
     content: '프롬프트에 새로운 문의가 도착했습니다.',
     linkUrl: `/inquiries/${receiverId}`,
     actorId: senderId,


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
- 새 문의가 달렸을 때 알림 생성
- 해당 문의 알림 클릭시 내 문의함으로 이동(inquiries/{receiverId})

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
- inquiry.service
   - 새 문의 등록 알림 생성 함수
 
**- notification.service**
   - createInquiryNotification(): 새 문의 등록 알림 생성 함수 

- notification.listener
   - 새로운 문의 등록 알림 리스너 생성


## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
<img width="2612" height="740" alt="스크린샷 2025-08-04 012611" src="https://github.com/user-attachments/assets/339b5b73-6bb2-476d-8d76-f8cf79a750d5" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->
문의 답변이 아니라 문의 등록 알림이므로 enum NotificationType에서 INQUIRY_REPLY  ->  NEW_INQUIRY로 변경 예정