### PR TITLE
[FIX] 프롬프트 다운로드 로직 수정

### DIFF
--- a/src/prompts/dtos/prompt.download.dto.ts
+++ b/src/prompts/dtos/prompt.download.dto.ts
@@ -3,5 +3,6 @@ export interface PromptDownloadResponseDTO {
   title: string;
   prompt: string;
   is_free: boolean;
+  is_paid: boolean;
   statusCode: number;
 }

--- a/src/prompts/services/prompt.download.service.ts
+++ b/src/prompts/services/prompt.download.service.ts
@@ -1,6 +1,7 @@
 import { PromptDownloadRepository } from '../repositories/prompt.download.repository';
 import { PromptDownloadResponseDTO } from '../dtos/prompt.download.dto';
 import { AppError } from '../../errors/AppError';
+import prisma from "../../config/prisma";
 
 export const PromptDownloadService = {
   async getPromptContent(userId: number, promptId: number): Promise<PromptDownloadResponseDTO> {
@@ -10,9 +11,25 @@ export const PromptDownloadService = {
       throw new AppError('해당 프롬프트를 찾을 수 없습니다.', 404, 'NotFound');
     }
 
-    // 유료 프롬프트인 경우 다운로드 불가 처리
+    let isPaid = false;
+
+     // 유료 프롬프트인 경우 결제 여부 확인
     if (!prompt.is_free) {
-      throw new AppError('해당 프롬프트는 무료가 아닙니다.', 403, 'Forbidden');
+      const purchase = await prisma.purchase.findFirst({
+        where: {
+          user_id: userId,
+          prompt_id: promptId,
+        },
+        include: {
+          payment: true,
+        },
+      });
+
+      isPaid = purchase?.payment?.status === 'Succeed';
+
+      if (!isPaid) {
+        throw new AppError('해당 프롬프트는 무료가 아니며, 결제가 완료되지 않았습니다.', 403, 'Forbidden');
+      }
     }
 
     return {
@@ -20,6 +37,7 @@ export const PromptDownloadService = {
       title: prompt.title,
       prompt: prompt.prompt,
       is_free: prompt.is_free,
+      is_paid: prompt.is_free ? true : isPaid,
       statusCode: 200,
     };
   }


### PR DESCRIPTION
## 📌 기능 설명
유료 프롬프트의 경우, 사용자가 결제를 완료한 경우에만 다운로드가 가능하도록 처리하는 기능입니다.
기존에는 무료 프롬프트만 다운로드가 가능했으나, 유료 프롬프트에 대한 접근 제어가 필요했습니다.

## 📌 구현 내용
- [ ] PromptDownloadService.getPromptContent() 내부 로직 개선
- [ ] 프롬프트가 유료인 경우(is_free === false) 다음 조건을 확인:
- [ ] 사용자가 해당 프롬프트를 구매했는지 확인 (Purchase)
- [ ] 결제 상태가 Succeed 인지 확인 (Payment.status)
- [ ] 조건을 만족하지 않으면 403 Forbidden 에러 반환
- [ ] 응답 DTO(PromptDownloadResponseDTO)에 is_paid 필드 추가

## 📌 구현 결과
<img width="1093" height="698" alt="image" src="https://github.com/user-attachments/assets/0bf2f4c2-90ac-44d2-8709-85e6b9bf43a5" />

## 📌 논의하고 싶은 점
