### PR TITLE
[FEAT] 새 프롬프트 알림 생성 구현(#131)

### DIFF
--- a/src/notifications/listeners/notification.listener.ts
+++ b/src/notifications/listeners/notification.listener.ts
@@ -4,6 +4,7 @@ import {
   createAnnouncementNotification,
   createFollowNotification,
   createInquiryNotification,
+  createPromptNotification,
 } from "../services/notification.service";
 
 
@@ -41,5 +42,14 @@ eventBus.on('inquiry.created', async (receiverId: number, senderId: number) => {
     await createInquiryNotification(receiverId, senderId);
   } catch (err) {
     console.error("[알림 리스너 오류]: 새로운 문의 알림 생성 실패", err);
+  }
+});
+
+// 새로운 프롬프트 업로드 알림 리스너
+eventBus.on('prompt.created', async (prompterId: number) => {
+  try {
+    await createPromptNotification(prompterId);
+  } catch (err) {
+    console.error("[알림 리스너 오류]: 새로운 프롬프트 업로드 알림 생성 실패", err);
   }
 });

--- a/src/notifications/repositories/notification.repository.ts
+++ b/src/notifications/repositories/notification.repository.ts
@@ -67,6 +67,20 @@ export const findUserByUserId = async (userId: number):Promise<User | null> => {
   return user;
 };
 
+// 특정 프롬프터를 구독 중인 사용자 목록 조회
+export const findUsersSubscribedToPrompter = async (prompterId: number) => {
+  const subscriptions = await prisma.notificationSubscription.findMany({
+    where: {
+      prompter_id: prompterId,
+    },
+    select: {
+      user_id: true, // 알림 받을 사용자 ID만 추출
+    },
+  });
+
+  return subscriptions.map((sub) => sub.user_id); // user_id로 이루어진 배열로 반환
+};
+
 // 알림 등록 (공통)
 export const createNotification = async ({
   userId = null,

--- a/src/prompts/services/prompt.service.ts
+++ b/src/prompts/services/prompt.service.ts
@@ -6,7 +6,7 @@ import { CreatePromptImageDto } from "../dtos/prompt-image.dto";
 import { v4 as uuidv4 } from "uuid";
 import { CreatePromptDto } from "../dtos/create-prompt.dto";
 import { UpdatePromptDto } from '../dtos/update-prompt.dto';
-
+import eventBus from '../../config/eventBus';
 /**
  * 프롬프트 검색 서비스
  */
@@ -68,7 +68,12 @@ export const createPromptWrite = async (
   user_id: number,
   dto: CreatePromptDto
 ) => {
-  return await promptRepository.createPromptWriteRepo(user_id, dto);
+  const prompt = await promptRepository.createPromptWriteRepo(user_id, dto);
+  
+  // 새 프롬프트 업로드 알림 이벤트 발생
+  eventBus.emit("prompt.created", user_id);
+  
+  return prompt;
 };
 
 export const getPromptById = async (promptId: number) => {


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
사용자가 알림 설정한 프롬프터가 새 프롬프트를 업로드했을 때 해당 사용자에게 알림이 가는 기능

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
- prompt.service
   - 새 프롬프트 알림 이벤트 호출
- notification.event
   - 새 프롬프트 알림 이벤트 생성
- notification.service
   - createPromptNotification(): 새 프롬프트 알림 생성 서비스 함수
- notification.repository 
   - findUsersSubscribedToPrompter(): 프롬프트를 업로드한 프롬프터를 알림설정한 사용자ID 목록 추출 함수
  
## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
<img width="2724" height="223" alt="스크린샷 2025-08-05 133334" src="https://github.com/user-attachments/assets/421fa5cd-7538-4b9f-a75c-05f0da56451e" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->