### PR TITLE
Feat: 메시지 내용 조회 API 구현

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import reportRouter from './reports/routes/report.route'; // 신고 라우터 im
 import announcementRouter from './announcements/routes/announcement.route'; // 공지사항 라우터 import
 import notificationRouter from './notifications/routes/notification.route'; // 알림 라우터 import
 import './notifications/listeners/notification.listener'; // 알림 리스터 import
+import messageRouter from './messages/routes/message.route';
 
 const PORT = 3000;
 const app = express();
@@ -88,6 +89,9 @@ app.use('/api/inquiries', inquiryRouter);
 app.use('/api/reports', reportRouter);
 // 알림 라우터
 app.use('/api/notifications', notificationRouter);
+
+// 메시지 라우터
+app.use('/api/messages', notificationRouter);
 
 // 예시 라우터
 app.get("/", (req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import express, { ErrorRequestHandler } from "express";
 import { responseHandler } from "./middlewares/responseHandler";
 import { errorHandler } from "./middlewares/errorHandler";
-
+import 'reflect-metadata';
 import passport from './config/passport';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ app.use('/api/reports', reportRouter);
 app.use('/api/notifications', notificationRouter);
 
 // 메시지 라우터
-app.use('/api/messages', notificationRouter);
+app.use('/api/messages', messageRouter);
 
 // 예시 라우터
 app.get("/", (req, res) => {

--- a/src/inquiries/controllers/inquiry.controller.ts
+++ b/src/inquiries/controllers/inquiry.controller.ts
@@ -8,6 +8,7 @@ import { validate } from "class-validator";
 import { AppError } from "../../errors/AppError";
 import { GetInquiriesDto } from "../dtos/get-inquiries.dto";
 import { CreateReplyDto } from "../dtos/create-reply.dto";
+import { MessageRepository } from "../../messages/repositories/message.repository";
 
 export class InquiryController {
   private inquiryService: InquiryService;
@@ -15,7 +16,8 @@ export class InquiryController {
   constructor() {
     this.inquiryService = new InquiryService(
       new InquiryRepository(),
-      new MemberRepository()
+      new MemberRepository(),
+      new MessageRepository(),
     );
   }
 

--- a/src/messages/controllers/message.controller.ts
+++ b/src/messages/controllers/message.controller.ts
@@ -1,0 +1,21 @@
+import { Request, Response, NextFunction } from "express";
+import { Service } from "typedi";
+import { MessageService } from "../services/message.service";
+
+@Service()
+export class MessageController {
+  constructor(private readonly messageService: MessageService) {}
+
+  getMessageById = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const message_id = parseInt(req.params.message_id, 10);
+      const currentUserId = (req.user as any).user_id;
+
+      const message = await this.messageService.getMessageById(message_id, currentUserId);
+
+      res.status(200).json(message);
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/messages/repositories/message.repository.ts
+++ b/src/messages/repositories/message.repository.ts
@@ -22,11 +22,18 @@ private prisma = new PrismaClient();
   /**
    * 메시지 단건 조회
    */
-  async findById(message_id: number): Promise<Message | null> {
-    return this.prisma.message.findUnique({
-      where: { message_id },
-    });
-  }
+  async findById(message_id: number): Promise<(Message & { sender: { nickname: string } }) | null> {
+  return this.prisma.message.findUnique({
+    where: { message_id },
+    include: {
+      sender: {
+        select: {
+          nickname: true, 
+        },
+      },
+    },
+  });
+}
 
   /**
    * 유저의 받은 메시지 목록

--- a/src/messages/routes/message.route.ts
+++ b/src/messages/routes/message.route.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { Container } from "typedi";
+import { MessageController } from "../controllers/message.controller";
+import { authenticateJwt } from "../../config/passport";
+
+const router = Router();
+const messageController = Container.get(MessageController);
+
+router.get("/messages/:message_id", authenticateJwt, messageController.getMessageById);
+
+export default router;

--- a/src/messages/routes/message.route.ts
+++ b/src/messages/routes/message.route.ts
@@ -6,6 +6,6 @@ import { authenticateJwt } from "../../config/passport";
 const router = Router();
 const messageController = Container.get(MessageController);
 
-router.get("/messages/:message_id", authenticateJwt, messageController.getMessageById);
+router.get("/:message_id", authenticateJwt, messageController.getMessageById);
 
 export default router;

--- a/src/messages/services/message.service.ts
+++ b/src/messages/services/message.service.ts
@@ -1,0 +1,35 @@
+import { Service } from "typedi";
+import { MessageRepository } from "../repositories/message.repository";
+import { AppError } from "../../errors/AppError";
+
+@Service()
+export class MessageService {
+  constructor(private readonly messageRepository: MessageRepository) {}
+
+  async getMessageById(message_id: number, currentUserId: number) {
+    const message = await this.messageRepository.findById(message_id);
+
+    if (!message) {
+      throw new AppError("존재하지 않는 메시지입니다.", 404, "NotFound");
+    }
+
+    if (message.receiver_id !== currentUserId) {
+      throw new AppError("해당 메시지에 접근할 수 없습니다.", 403, "Forbidden");
+    }
+
+    if (!message.is_read) {
+      await this.messageRepository.markAsRead(message_id);
+    }
+
+    return {
+      message: "메시지 내용 조회 성공",
+      message_id: message.message_id,
+      title: message.title,
+      sender: message.sender.nickname,
+      created_at: message.created_at,
+      content: message.body,
+      is_read: true,
+      statusCode: 200,
+    };
+  }
+}


### PR DESCRIPTION
## 📌 기능 설명
메시지 상세 조회 API를 구현했습니다.
로그인된 사용자가 수신한 메시지를 단건 조회하며, 메시지를 읽음 처리합니다.

## 📌 구현 내용
GET /api/messages/:message_id
특정 메시지 ID에 해당하는 메시지를 조회합니다.
요청자는 반드시 해당 메시지의 **수신자(receiver)**여야 하며, 아니면 403 Forbidden을 반환합니다.

- [ ] 인증 적용
- [ ] Authorization: Bearer {access_token} 헤더로 인증 필요
- [ ] 인증 실패 시 401 Unauthorized 반환
- [ ] 조회 시 메시지 읽음 처리
- [ ] is_read = true 및 read_at 업데이트

### 응답 데이터 구조
{
  "message": "메시지 내용 조회 성공",
  "message_id": 123,
  "title": "제목",
  "sender": "보낸사람 닉네임",
  "created_at": "2025-07-22T00:00:00.000Z",
  "content": "본문 내용",
  "is_read": true,
  "statusCode": 200
}

### 예외 처리
- [ ] 존재하지 않는 메시지: 404 Not Found
- [ ] 다른 사용자의 메시지 접근 시: 403 Forbidden
- [ ] 인증되지 않은 접근: 401 Unauthorized

### 비즈니스 로직 구성
- [ ] MessageService에서 유효성 검증 및 읽음 처리 수행
- [ ] MessageRepository.findById()에서 sender.nickname 포함하여 조회

## 📌 구현 결과
<img width="1076" height="826" alt="image" src="https://github.com/user-attachments/assets/dd4f80aa-43e5-4c6e-bbfb-8ae9931d5034" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->