### PR TITLE
Feat: 메시지 목록 조회 API 구현

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@types/passport-google-oauth20':
         specifier: ^2.0.16
         version: 2.0.16
+      '@types/passport-kakao':
+        specifier: ^1.0.3
+        version: 1.0.3
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -53,6 +56,9 @@ importers:
       passport-jwt:
         specifier: ^4.0.1
         version: 4.0.1
+      passport-kakao:
+        specifier: ^1.0.1
+        version: 1.0.1
       passport-naver-v2:
         specifier: ^2.0.8
         version: 2.0.8
@@ -763,6 +769,9 @@ packages:
   '@types/passport-jwt@4.0.1':
     resolution: {integrity: sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==}
 
+  '@types/passport-kakao@1.0.3':
+    resolution: {integrity: sha512-McK5kpeiOptvjIPkiA/QS3k82//z5JM7Y3yBLMDvEA0QMMhFMcWUHhyebL1Qy+0i0n8jS+Oe4U6xAvkU22SXXA==}
+
   '@types/passport-oauth2@1.8.0':
     resolution: {integrity: sha512-6//z+4orIOy/g3zx17HyQ71GSRK4bs7Sb+zFasRoc2xzlv7ZCJ+vkDBYFci8U6HY+or6Zy7ajf4mz4rK7nsWJQ==}
 
@@ -1436,6 +1445,9 @@ packages:
   oauth@0.10.2:
     resolution: {integrity: sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==}
 
+  oauth@0.9.15:
+    resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1472,8 +1484,15 @@ packages:
   passport-jwt@4.0.1:
     resolution: {integrity: sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==}
 
+  passport-kakao@1.0.1:
+    resolution: {integrity: sha512-uItaYRVrTHL6iGPMnMZvPa/O1GrAdh/V6EMjOHcFlQcVroZ9wgG7BZ5PonMNJCxfHQ3L2QVNRnzhKWUzSsumbw==}
+
   passport-naver-v2@2.0.8:
     resolution: {integrity: sha512-CA0u+aA4K4Zf5e3dSd47agOS69ULOdBGei7CZY2BN1cEbLnhnc6OalFPvnXLuEKT8I4IuGwvh3EBZCST2FoI+A==}
+
+  passport-oauth2@1.1.2:
+    resolution: {integrity: sha512-wpsGtJDHHQUjyc9WcV9FFB0bphFExpmKtzkQrxpH1vnSr6RcWa3ZEGHx/zGKAh2PN7Po9TKYB1fJeOiIBspNPA==}
+    engines: {node: '>= 0.4.0'}
 
   passport-oauth2@1.8.0:
     resolution: {integrity: sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==}
@@ -1515,6 +1534,10 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  pkginfo@0.3.1:
+    resolution: {integrity: sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==}
+    engines: {node: '>= 0.4.0'}
 
   prisma@6.12.0:
     resolution: {integrity: sha512-pmV7NEqQej9WjizN6RSNIwf7Y+jeh9mY1JEX2WjGxJi4YZWexClhde1yz/FuvAM+cTwzchcMytu2m4I6wPkIzg==}
@@ -3110,6 +3133,11 @@ snapshots:
       '@types/jsonwebtoken': 9.0.10
       '@types/passport-strategy': 0.2.38
 
+  '@types/passport-kakao@1.0.3':
+    dependencies:
+      '@types/express': 5.0.3
+      '@types/passport': 1.0.17
+
   '@types/passport-oauth2@1.8.0':
     dependencies:
       '@types/express': 5.0.3
@@ -3831,6 +3859,8 @@ snapshots:
 
   oauth@0.10.2: {}
 
+  oauth@0.9.15: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -3860,9 +3890,20 @@ snapshots:
       jsonwebtoken: 9.0.2
       passport-strategy: 1.0.0
 
+  passport-kakao@1.0.1:
+    dependencies:
+      passport-oauth2: 1.1.2
+      pkginfo: 0.3.1
+
   passport-naver-v2@2.0.8:
     dependencies:
       passport-oauth2: 1.8.0
+
+  passport-oauth2@1.1.2:
+    dependencies:
+      oauth: 0.9.15
+      passport-strategy: 1.0.0
+      uid2: 0.0.4
 
   passport-oauth2@1.8.0:
     dependencies:
@@ -3898,6 +3939,8 @@ snapshots:
   pause@0.0.1: {}
 
   picomatch@2.3.1: {}
+
+  pkginfo@0.3.1: {}
 
   prisma@6.12.0(typescript@5.8.3):
     dependencies:

--- a/src/messages/controllers/message.controller.ts
+++ b/src/messages/controllers/message.controller.ts
@@ -18,4 +18,21 @@ export class MessageController {
       next(error);
     }
   };
+
+  getReceivedMessages = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const currentUserId = (req.user as any).user_id;
+    const { limit, cursor, is_read } = req.query;
+
+    const result = await this.messageService.getReceivedMessages(currentUserId, {
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+      cursor: cursor ? parseInt(cursor as string, 10) : undefined,
+      is_read: is_read === 'true' ? true : is_read === 'false' ? false : undefined,
+    });
+
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+};
 }

--- a/src/messages/routes/message.route.ts
+++ b/src/messages/routes/message.route.ts
@@ -6,6 +6,7 @@ import { authenticateJwt } from "../../config/passport";
 const router = Router();
 const messageController = Container.get(MessageController);
 
+router.get('/', authenticateJwt, messageController.getReceivedMessages); 
 router.get("/:message_id", authenticateJwt, messageController.getMessageById);
 
 export default router;

--- a/src/messages/services/message.service.ts
+++ b/src/messages/services/message.service.ts
@@ -32,4 +32,37 @@ export class MessageService {
       statusCode: 200,
     };
   }
+
+  async getReceivedMessages(currentUserId: number, query: {
+  limit?: number;
+  cursor?: number;
+  is_read?: boolean;
+}) {
+  const limit = query.limit ?? 10;
+  const cursor = query.cursor;
+  const is_read = query.is_read;
+
+  const { messages, hasNextPage } = await this.messageRepository.findReceivedMessagesWithCursor({
+    receiver_id: currentUserId,
+    limit,
+    cursor,
+    is_read,
+  });
+
+  return {
+    message: "메시지 목록 조회 성공",
+    messages: messages.map(msg => ({
+      message_id: msg.message_id,
+      title: msg.title,
+      sender: msg.sender.nickname,
+      created_at: msg.created_at.toISOString().split('T')[0], // 날짜만
+      is_read: msg.is_read,
+    })),
+    pagination: {
+      nextCursor: hasNextPage ? messages[messages.length - 1].message_id : null,
+      limit,
+    },
+    statusCode: 200,
+  };
+}
 }


### PR DESCRIPTION
## 📌 기능 설명
수신한 메시지를 조회하는 메시지 목록 API를 구현했습니다.
커서 기반 페이지네이션을 지원하며, 읽음 여부(is_read) 필터도 사용할 수 있습니다.

## 📌 구현 내용
### GET /api/messages
- [ ] 로그인된 사용자의 수신 메시지 목록을 조회
- [ ] 커서 기반 페이지네이션 방식 사용
- [ ] limit: 페이지당 개수 (기본값: 10)
- [ ] cursor: 이전 페이지의 마지막 메시지 ID (선택)
- [ ] is_read 쿼리 파라미터로 읽음 여부 필터링 가능 (true | false)

### 응답 필드
`{
  "message": "메시지 목록 조회 성공",
  "messages": [
    {
      "message_id": 9876,
      "title": "프롬프트 가이드라인 위반 경고",
      "sender": "관리자",
      "created_at": "2025-07-22",
      "is_read": false
    }
  ],
  "pagination": {
    "nextCursor": 9875,
    "limit": 10
  },
  "statusCode": 200
}`

### 비즈니스 로직
- [ ] receiver_id가 현재 로그인 유저와 일치하는 메시지만 조회
- [ ] 삭제된 메시지(is_deleted = true)는 제외
- [ ] sender.nickname 포함해서 응답에 전달

### 예외 처리
- [ ] 인증되지 않은 요청 시 401 Unauthorized 반환
- [ ] 서버 오류 시 500 Internal Server Error 처리

## 📌 구현 결과
<img width="1082" height="867" alt="image" src="https://github.com/user-attachments/assets/f6675af9-fb53-4180-8781-3ea9015c8fd4" />
<img width="712" height="317" alt="image" src="https://github.com/user-attachments/assets/01a0af9f-7aa3-44b1-8e5d-149f22f2577b" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->