### PR TITLE
Feat: 메시지 삭제 API 구현

### DIFF
--- a/src/messages/controllers/message.controller.ts
+++ b/src/messages/controllers/message.controller.ts
@@ -35,4 +35,17 @@ export class MessageController {
     next(error);
   }
 };
+
+deleteMessage = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const message_id = parseInt(req.params.message_id, 10);
+    const user_id = (req.user as any).user_id;
+
+    const result = await this.messageService.deleteMessage(message_id, user_id);
+
+    res.status(200).json(result);
+  } catch (err) {
+    next(err);
+  }
+};
 }

--- a/src/messages/routes/message.route.ts
+++ b/src/messages/routes/message.route.ts
@@ -8,5 +8,6 @@ const messageController = Container.get(MessageController);
 
 router.get('/', authenticateJwt, messageController.getReceivedMessages); 
 router.get("/:message_id", authenticateJwt, messageController.getMessageById);
+router.patch("/:message_id", authenticateJwt, messageController.deleteMessage);
 
 export default router;

--- a/src/messages/routes/message.route.ts
+++ b/src/messages/routes/message.route.ts
@@ -8,6 +8,6 @@ const messageController = Container.get(MessageController);
 
 router.get('/', authenticateJwt, messageController.getReceivedMessages); 
 router.get("/:message_id", authenticateJwt, messageController.getMessageById);
-router.patch("/:message_id", authenticateJwt, messageController.deleteMessage);
+router.patch("/:message_id/delete", authenticateJwt, messageController.deleteMessage);
 
 export default router;

--- a/src/messages/services/message.service.ts
+++ b/src/messages/services/message.service.ts
@@ -65,4 +65,23 @@ export class MessageService {
     statusCode: 200,
   };
 }
+
+async deleteMessage(message_id: number, currentUserId: number) {
+  const message = await this.messageRepository.findById(message_id);
+
+  if (!message) {
+    throw new AppError("존재하지 않는 메시지입니다.", 404, "NotFound");
+  }
+
+  if (message.receiver_id !== currentUserId) {
+    throw new AppError("해당 메시지를 삭제할 권한이 없습니다.", 403, "Forbidden");
+  }
+
+  await this.messageRepository.softDelete(message_id);
+
+  return {
+    message: "메시지가 성공적으로 삭제되었습니다.",
+    statusCode: 200,
+  };
+}
 }


### PR DESCRIPTION
## 📌 기능 설명
사용자가 수신한 메시지를 삭제하는 API를 구현했습니다.
삭제는 실제 DB에서 제거하는 방식이 아닌, is_deleted 플래그를 true로 설정하는 소프트 딜리트 방식입니다.

## 📌 구현 내용
### PATCH /api/messages/:message_id/delete
- [ ] 로그인한 사용자가 받은 메시지를 삭제 처리
- [ ] is_deleted = true 로 상태 업데이트
- [ ] 삭제된 메시지는 목록/상세 조회에서 제외됨
- [ ] 응답은 단순 성공 메시지 반환 (추가 상태는 포함하지 않음)

### 접근 제어
- [ ] 본인이 수신한 메시지만 삭제 가능
- [ ] 다른 유저의 메시지 삭제 시 403 Forbidden 반환

### 예외 처리
- [ ] 존재하지 않는 메시지: 404 Not Found
- [ ] 삭제 권한 없음: 403 Forbidden
- [ ] 인증 실패: 401 Unauthorized

### 응답 예시
`{
  "message": "메시지가 성공적으로 삭제되었습니다.",
  "statusCode": 200
}
`

## 📌 구현 결과
<img width="1107" height="616" alt="image" src="https://github.com/user-attachments/assets/3a60f6c8-7b3b-46a0-af5c-10de3333489c" />
<img width="1100" height="577" alt="image" src="https://github.com/user-attachments/assets/a3fa6976-908c-4266-b4bd-30e788467a95" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->