### PR TITLE
Feat: 메시지 읽음 처리 API 구현

### DIFF
--- a/src/messages/controllers/message.controller.ts
+++ b/src/messages/controllers/message.controller.ts
@@ -36,6 +36,18 @@ export class MessageController {
   }
 };
 
+markAsRead = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const message_id = parseInt(req.params.message_id, 10);
+    const user_id = (req.user as any).user_id;
+
+    const result = await this.messageService.markMessageAsRead(message_id, user_id);
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+
 deleteMessage = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const message_id = parseInt(req.params.message_id, 10);

--- a/src/messages/routes/message.route.ts
+++ b/src/messages/routes/message.route.ts
@@ -8,6 +8,7 @@ const messageController = Container.get(MessageController);
 
 router.get('/', authenticateJwt, messageController.getReceivedMessages); 
 router.get("/:message_id", authenticateJwt, messageController.getMessageById);
+router.patch('/:message_id/read', authenticateJwt, messageController.markAsRead);
 router.patch("/:message_id/delete", authenticateJwt, messageController.deleteMessage);
 
 export default router;

--- a/src/messages/services/message.service.ts
+++ b/src/messages/services/message.service.ts
@@ -66,6 +66,27 @@ export class MessageService {
   };
 }
 
+async markMessageAsRead(message_id: number, currentUserId: number) {
+  const message = await this.messageRepository.findById(message_id);
+
+  if (!message) {
+    throw new AppError("존재하지 않는 메시지입니다.", 404, "NotFound");
+  }
+
+  if (message.receiver_id !== currentUserId) {
+    throw new AppError("해당 메시지에 접근할 수 없습니다.", 403, "Forbidden");
+  }
+
+  if (!message.is_read) {
+    await this.messageRepository.markAsRead(message_id);
+  }
+
+  return {
+    message: "메시지가 읽음 처리되었습니다.",
+    statusCode: 200,
+  };
+}
+
 async deleteMessage(message_id: number, currentUserId: number) {
   const message = await this.messageRepository.findById(message_id);
 


### PR DESCRIPTION
## 📌 기능 설명
사용자가 수신한 메시지를 읽음 처리하는 API를 구현했습니다.
요청 시 해당 메시지의 is_read 값을 true로 설정하고, read_at을 현재 시간으로 업데이트합니다.

## 📌 구현 내용
### PATCH /api/messages/:message_id/read
- [ ] 로그인한 사용자가 받은 메시지를 읽음 처리
- [ ] is_read 값이 false일 경우에만 is_read = true, read_at = now()로 갱신
- [ ] 이미 읽은 메시지는 중복 처리 없이 통과

### 접근 제어
- [ ] 본인이 받은 메시지만 읽음 처리 가능
- [ ] 타인의 메시지 접근 시 403 Forbidden 에러 반환

### 예외 처리
- [ ] 인증되지 않은 사용자 → 401 Unauthorized
- [ ] 존재하지 않는 메시지 → 404 Not Found
- [ ] 다른 유저 메시지 접근 시 → 403 Forbidden

### 응답 예시
`{
  "message": "메시지가 읽음 처리되었습니다.",
  "message_id": 12345,
  "is_read": true,
  "statusCode": 200
}`

## 📌 구현 결과
<img width="1097" height="622" alt="image" src="https://github.com/user-attachments/assets/8073c3be-c32e-4da6-a55c-d38dc2829f4d" />
<img width="1107" height="617" alt="image" src="https://github.com/user-attachments/assets/4e8ff549-6a46-4ac1-a75d-9a3cb7f067cc" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->