### PR TITLE
[BUG]: 서버 cannot get 오류 해결

### DIFF
--- a/dist/config/social/kakao.js
+++ b/dist/config/social/kakao.js
@@ -17,6 +17,10 @@ const passport_1 = __importDefault(require("passport"));
 const passport_kakao_1 = require("passport-kakao");
 const prisma_1 = __importDefault(require("../prisma"));
 function configureKakaoStrategy() {
+    // 환경 변수 값 로그 찍기
+    console.log('KAKAO_CLIENT_ID:', process.env.KAKAO_CLIENT_ID);
+    console.log('KAKAO_CLIENT_SECRET:', process.env.KAKAO_CLIENT_SECRET);
+    console.log('KAKAO_CALLBACK_URL:', process.env.KAKAO_CALLBACK_URL);
     passport_1.default.use(new passport_kakao_1.Strategy({
         clientID: process.env.KAKAO_CLIENT_ID,
         clientSecret: process.env.KAKAO_CLIENT_SECRET,

--- a/src/config/passport.ts
+++ b/src/config/passport.ts
@@ -1,4 +1,6 @@
 import passport from "passport";
+import dotenv from 'dotenv';
+dotenv.config(); 
 import {
   Strategy as JwtStrategy,
   ExtractJwt,

--- a/src/config/social/kakao.ts
+++ b/src/config/social/kakao.ts
@@ -2,13 +2,9 @@ import passport from "passport";
 import { Strategy as KakaoStrategy } from "passport-kakao";
 import prisma from "../prisma";
 import dotenv from 'dotenv';
-dotenv.config();
+dotenv.config(); 
 
 export function configureKakaoStrategy() {
-  // 환경 변수 값 로그 찍기
-  console.log('KAKAO_CLIENT_ID:', process.env.KAKAO_CLIENT_ID);
-  console.log('KAKAO_CLIENT_SECRET:', process.env.KAKAO_CLIENT_SECRET);
-  console.log('KAKAO_CALLBACK_URL:', process.env.KAKAO_CALLBACK_URL);
   passport.use(
     new KakaoStrategy(
       {

--- a/src/config/social/kakao.ts
+++ b/src/config/social/kakao.ts
@@ -3,6 +3,10 @@ import { Strategy as KakaoStrategy } from "passport-kakao";
 import prisma from "../prisma";
 
 export function configureKakaoStrategy() {
+  // 환경 변수 값 로그 찍기
+  console.log('KAKAO_CLIENT_ID:', process.env.KAKAO_CLIENT_ID);
+  console.log('KAKAO_CLIENT_SECRET:', process.env.KAKAO_CLIENT_SECRET);
+  console.log('KAKAO_CALLBACK_URL:', process.env.KAKAO_CALLBACK_URL);
   passport.use(
     new KakaoStrategy(
       {

--- a/src/config/social/kakao.ts
+++ b/src/config/social/kakao.ts
@@ -1,6 +1,8 @@
 import passport from "passport";
 import { Strategy as KakaoStrategy } from "passport-kakao";
 import prisma from "../prisma";
+import dotenv from 'dotenv';
+dotenv.config();
 
 export function configureKakaoStrategy() {
   // 환경 변수 값 로그 찍기


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
<오류 해결 전 상황>
1. 서버 실행 폴더에 .git이 없어서 최신 코드를 반영하지 못했음
2. 빌드 실행 시 오류 발생
3. .env에 카카오 관련 설정들이 없음
4. 카카오 인증 단계에서 .env파일을 인식할 수 없음(console.log(process.env.KAKAO_CLIENT_ID); // ❌ undefined)
5. PM2가 이전 구버전 빌드 파일을 바라보고 있었음

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
<위 문제를 해결한 방법>
1. 서버 실행 폴더에 promptplace-BE 레포를 연결하여 깃과 연동
2. complete-signup.dto파일의 CompleteSignupDto에서 email, name, nickname 필드에 !를 붙여 초기화 에러 해결
3. .env에 KAKAO_CLIENT_ID, KAKAO_CLIENT_SECRET, KAKAO_CALLBACK_URL를 추가
4. kakao.ts, passport.ts 최상단에 `import dotenv from 'dotenv';`,  `dotenv.config();, 를 추가하여 확실히 호출
5. `pm2 delete all` 후 서버 새로 시작하면서 해결

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
<img width="2879" height="1533" alt="스크린샷 2025-08-07 150330" src="https://github.com/user-attachments/assets/849bbab3-d99c-482f-b576-9da30c751d05" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->
코드 푸시하고난 후 해야할 일
1. ssh로 서버 접속
2. /home/ubuntu/app-backup경로로 이동
3. rm -rf dist && pnpm build && pm2 restart promptplace 실행