### PR TITLE
Chore: CORS 설정 추가

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,13 +32,26 @@ app.use(responseHandler);
 app.use(express.json());
 
 // CORS 설정
-const allowedOrigins = ['https://promptplace-develop.vercel.app'];
+const allowedOrigins = [
+  'https://www.promptplace.kr', 
+  'http://localhost:5173',      
+  'https://promptplace-develop.vercel.app' 
+];
 
 app.use(cors({
-  origin: allowedOrigins,
-  credentials: true, // 세션 쿠키 등 인증 정보 주고받을 경우 true
+  origin: function (origin, callback) {
+    // origin이 undefined일 수 있으므로 체크 필요
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+  credentials: true,
 }));
 
+// Preflight 요청에 대한 응답을 보장
+app.options('*', cors());
 
 // Session 설정 (OAuth용)
 app.use(


### PR DESCRIPTION
## 📌 기능 설명
CORS 허용 도메인 추가와 Preflight 요청에 대한 처리를 추가했습니다.

## 📌 구현 내용
### 다음 도메인을 allowedOrigins에 명시:
- [ ] http://localhost:5173 (프론트 로컬 개발용)
- [ ] https://www.promptplace.kr (배포용 프론트)
- [ ] https://promptplace-develop.vercel.app (개발 배포용 프론트)
- [ ] Preflight 요청(OPTIONS)을 안전하게 처리하기 위해 app.options('*', cors()) 추가

## 📌 구현 결과


## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->