### PR TITLE
Fix/#168 특정 회원 정보 조회 및 이력 조회 API 접근 권한 수정

### DIFF
--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -9,7 +9,7 @@ import { CreateHistoryDto } from "../dtos/create-history.dto";
 import { UpdateHistoryDto } from "../dtos/update-history.dto";
 import { CreateSnsDto } from "../dtos/create-sns.dto";
 import { UpdateSnsDto } from "../dtos/update-sns.dto";
-import eventBus from '../../config/eventBus';
+import eventBus from "../../config/eventBus";
 @Service()
 export class MemberService {
   constructor(private memberRepository: MemberRepository) {}
@@ -101,14 +101,6 @@ export class MemberService {
   }
 
   async getMemberById(requesterId: number, memberId: number) {
-    if (requesterId !== memberId) {
-      throw new AppError(
-        "해당 회원 정보에 접근할 권한이 없습니다.",
-        403,
-        "Forbidden"
-      );
-    }
-
     const member = await this.memberRepository.findUserWithIntroById(memberId);
 
     if (!member) {
@@ -216,7 +208,7 @@ export class MemberService {
       throw new AppError(
         "해당 이력을 삭제할 권한이 없습니다.",
         403,
-        "Forbidden",
+        "Forbidden"
       );
     }
 
@@ -361,7 +353,10 @@ export class MemberService {
     }
 
     // 팔로우 생성
-    const follow = await this.memberRepository.createFollow(followerId, followingId);
+    const follow = await this.memberRepository.createFollow(
+      followerId,
+      followingId
+    );
 
     // 팔로우 알림 이벤트 발생
     eventBus.emit("follow.created", followerId, followingId);

--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -216,14 +216,6 @@ export class MemberService {
   }
 
   async getHistories(requesterId: number, memberId: number) {
-    if (requesterId !== memberId) {
-      throw new AppError(
-        "해당 회원의 이력을 조회할 권한이 없습니다.",
-        403,
-        "Forbidden"
-      );
-    }
-
     const user = await this.memberRepository.findUserById(memberId);
     if (!user) {
       throw new AppError("해당 회원을 찾을 수 없습니다.", 404, "NotFound");


### PR DESCRIPTION
## 📌 기능 설명
회원 정보 조회 및 이력 조회 API의 접근 권한을 수정하여 타인의 정보도 조회할 수 있도록 개선

## 📌 구현 내용

### 1. 특정 회원 정보 조회 API 권한 수정
- **API**: `GET /api/members/{memberId}`
- **기존**: 본인 정보만 조회 가능 (타인 조회 시 403 Forbidden 에러)
- **수정 후**: 모든 사용자가 타인의 정보 조회 가능
- **변경 사항**:
  ```typescript
  // 기존 코드 제거
  if (requesterId !== memberId) {
    throw new AppError("해당 회원 정보에 접근할 권한이 없습니다.", 403, "Forbidden");
  }
  ```

### 2. 회원 이력 조회 API 권한 수정  
- **API**: `GET /api/members/{memberId}/histories`
- **기존**: 본인 이력만 조회 가능 (타인 조회 시 403 Forbidden 에러)
- **수정 후**: 모든 사용자가 타인의 이력 조회 가능
- **변경 사항**:
  ```typescript
  // 기존 코드 제거
  if (requesterId !== memberId) {
    throw new AppError("해당 회원의 이력을 조회할 권한이 없습니다.", 403, "Forbidden");
  }
  ```

### 3. 반환되는 정보
**회원 정보 조회 시 반환 데이터**:
```json
{
  "member_id": 123,
  "email": "user@example.com",
  "name": "홍길동",
  "nickname": "프롬프트러버", 
  "intros": "안녕하세요! 프롬프트 전문가입니다.",
  "created_at": "2024-01-15T10:30:00Z",
  "updated_at": "2024-01-15T10:30:00Z",
  "status": 1
}
```

**이력 조회 시 반환 데이터**:
```json
[
  {
    "type": "PROMPT_PURCHASE",
    "title": "GPT 프롬프트 모음집 구매",
    "description": "효과적인 GPT 프롬프트 모음",
    "amount": 5000,
    "created_at": "2024-01-15T10:30:00Z"
  },
  {
    "type": "PROMPT_UPLOAD", 
    "title": "마케팅 프롬프트 업로드",
    "description": "마케팅 카피 생성 프롬프트",
    "amount": 0,
    "created_at": "2024-01-14T15:20:00Z"
  }
]
```

## 📌 구현 결과

### 테스트 예시
```bash
# 타인의 회원 정보 조회 (이제 403 에러 없음)
GET /api/members/123
Authorization: Bearer {jwt_token}

# 타인의 이력 조회 (이제 403 에러 없음)  
GET /api/members/123/histories
Authorization: Bearer {jwt_token}
```

## 📌 논의하고 싶은 점