### PR TITLE
fix: 회원 이력 조회 로직 변경

### DIFF
--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -221,49 +221,7 @@ export class MemberService {
       throw new AppError("해당 회원을 찾을 수 없습니다.", 404, "NotFound");
     }
 
-    const purchases = await this.memberRepository.findPurchasesByUserId(
-      memberId
-    );
-    const uploads = await this.memberRepository.findPromptsByUserId(memberId);
-    const withdrawals = await this.memberRepository.findWithdrawalsByUserId(
-      memberId
-    );
-
-    const purchaseHistories = purchases.map((p) => ({
-      type: "PROMPT_PURCHASE",
-      title: `${p.prompt.title} 구매`,
-      description: p.prompt.description,
-      amount: p.amount,
-      created_at: p.created_at,
-    }));
-
-    const uploadHistories = uploads.map((p) => ({
-      type: "PROMPT_UPLOAD",
-      title: `${p.title} 업로드`,
-      description: p.description,
-      amount: 0,
-      created_at: p.created_at,
-    }));
-
-    const withdrawalHistories = withdrawals.map((w) => ({
-      type: "WITHDRAWAL",
-      title: "수익 출금 요청",
-      description: "프롬프트 판매 수익 출금",
-      amount: w.amount,
-      created_at: w.created_at,
-    }));
-
-    const allHistories = [
-      ...purchaseHistories,
-      ...uploadHistories,
-      ...withdrawalHistories,
-    ];
-
-    allHistories.sort(
-      (a, b) => b.created_at.getTime() - a.created_at.getTime()
-    );
-
-    return allHistories;
+    return await this.memberRepository.findHistoriesByUserId(memberId);
   }
 
   async createSns(userId: number, createSnsDto: CreateSnsDto) {


### PR DESCRIPTION
## 📌 기능 설명
회원 이력 조회 API의 데이터 조회 로직을 개선하여 UserHistory 테이블을 직접 조회하도록 변경

## 📌 구현 내용

### 1. 기존 문제점
- **복잡한 다중 테이블 조회**: `purchase`, `prompt`, `withdrawRequest` 3개 테이블을 각각 조회
- **데이터 변환 로직**: 각 테이블 데이터를 "이력" 형태로 가공하는 복잡한 매핑 로직
- **실제 이력 테이블 미사용**: `UserHistory` 테이블에 데이터가 있어도 조회하지 않음
- **성능 이슈**: 불필요한 다중 쿼리 실행

### 2. 개선된 구현
**API**: `GET /api/members/{memberId}/histories`

**변경 전**:
```typescript
async getHistories(requesterId: number, memberId: number) {
  // 3개 테이블 조회
  const purchases = await this.memberRepository.findPurchasesByUserId(memberId);
  const uploads = await this.memberRepository.findPromptsByUserId(memberId);
  const withdrawals = await this.memberRepository.findWithdrawalsByUserId(memberId);
  
  // 복잡한 데이터 변환 로직 (40+ 라인)
  const purchaseHistories = purchases.map((p) => ({ /* 변환 로직 */ }));
  const uploadHistories = uploads.map((p) => ({ /* 변환 로직 */ }));
  const withdrawalHistories = withdrawals.map((w) => ({ /* 변환 로직 */ }));
  
  // 데이터 합치기 및 정렬
  const allHistories = [...purchaseHistories, ...uploadHistories, ...withdrawalHistories];
  allHistories.sort((a, b) => b.created_at.getTime() - a.created_at.getTime());
  
  return allHistories;
}
```

**변경 후**:
```typescript
async getHistories(requesterId: number, memberId: number) {
  const user = await this.memberRepository.findUserById(memberId);
  if (!user) {
    throw new AppError("해당 회원을 찾을 수 없습니다.", 404, "NotFound");
  }

  return await this.memberRepository.findHistoriesByUserId(memberId);
}
```

### 3. Repository 메서드 활용
기존에 구현되어 있던 `findHistoriesByUserId` 메서드를 활용:
```typescript
async findHistoriesByUserId(userId: number) {
  return await prisma.userHistory.findMany({ where: { user_id: userId } });
}
```

## 📌 구현 결과

### 성능 개선
- **쿼리 수 감소**: 3개 → 1개 테이블 조회로 성능 향상
- **코드 복잡도 감소**: 40+ 라인 → 3라인으로 단순화
- **메모리 사용량 감소**: 불필요한 데이터 변환 로직 제거

### 기능 정상화
- **실제 이력 데이터 반환**: `UserHistory` 테이블의 실제 데이터가 정상적으로 조회됨
- **데이터 일관성**: 별도의 데이터 변환 없이 원본 이력 데이터 그대로 반환
- **확장성**: 향후 이력 유형 추가 시 테이블 스키마만 수정하면 됨

### API 응답 예시
```json
[
  {
    "history_id": 1,
    "user_id": 123,
    "type": "PROMPT_PURCHASE",
    "title": "GPT 프롬프트 구매",
    "description": "마케팅 카피 생성 프롬프트",
    "amount": 5000,
    "created_at": "2024-01-15T10:30:00Z",
    "updated_at": "2024-01-15T10:30:00Z"
  },
  {
    "history_id": 2,
    "user_id": 123,
    "type": "CUSTOM_ACTIVITY",
    "title": "프로필 업데이트",
    "description": "프로필 정보 수정",
    "amount": 0,
    "created_at": "2024-01-14T15:20:00Z",
    "updated_at": "2024-01-14T15:20:00Z"
  }
]
```

## 📌 논의하고 싶은 점