### PR TITLE
feat/#175 프롬프트 팁 및 공지사항 상세정보 조회 구현

### DIFF
--- a/src/announcements/controllers/announcement.controller.ts
+++ b/src/announcements/controllers/announcement.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import {
   findAnnouncementList,
+  getAnnouncementService,
   createAnnouncementService,
   patchAnnouncementService,
   deleteAnnouncementService,
@@ -21,6 +22,22 @@ export const getAnnouncementList = async (
 ) => {
   try {
     const result = await findAnnouncementList(req.query.page, req.query.size);
+    return res.success({
+      data: result,
+    });
+  } catch (err: any) {
+    console.error(err);
+    return res.status(500).json({
+      error: err.name || "InternalServerError",
+      message: err.message || "공지사항 조회 중 오류가 발생했습니다.",
+      statusCode: err.statusCode || 500,
+    });
+  }
+};
+
+export const getAnnouncement = async (req: Request, res: Response) => {
+  try {
+    const result = await getAnnouncementService(req.params.announcementId);
     return res.success({
       data: result,
     });

--- a/src/announcements/repositories/announcement.repository.ts
+++ b/src/announcements/repositories/announcement.repository.ts
@@ -14,6 +14,14 @@ export const findAnnouncements = async (page: number, size: number) => {
   });
 };
 
+export const getAnnouncementRepository = async (announcementId: string) => {
+  const parsedAnnouncementId = parseInt(announcementId, 10);
+
+  return await prisma.announcement.findUnique({
+    where: { announcement_id: parsedAnnouncementId },
+  });
+};
+
 export const createAnnouncementRepository = async (data: any) => {
   return await prisma.announcement.create({
     data: {

--- a/src/announcements/routes/announcement.route.ts
+++ b/src/announcements/routes/announcement.route.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import {
   getAnnouncementList,
+  getAnnouncement,
   createAnnouncement,
   patchAnnouncement,
   deleteAnnouncement,
@@ -14,6 +15,7 @@ const router = express.Router({ mergeParams: true });
 router.get("/", getAnnouncementList);
 
 // 관리자만 접근 가능
+router.get("/:announcementId/details", authenticateJwt, isAdmin, getAnnouncement);
 router.post("/", authenticateJwt, isAdmin, createAnnouncement);
 router.patch("/:announcementId", authenticateJwt, isAdmin, patchAnnouncement);
 router.patch("/:announcementId/delete", authenticateJwt, isAdmin, deleteAnnouncement);

--- a/src/announcements/services/announcement.service.ts
+++ b/src/announcements/services/announcement.service.ts
@@ -2,6 +2,7 @@ import { Announcement } from "@prisma/client";
 import { mapToAnnouncementListDTO, mapToCreateAnnouncementDTO } from "../dtos/announcement.dto";
 import {
   findAnnouncements,
+  getAnnouncementRepository,
   createAnnouncementRepository,
   updateAnnouncementRepository,
   removeAnnouncementRepository,
@@ -19,6 +20,18 @@ export const findAnnouncementList = async (rawPage?: string, rawSize?: string) =
 
   return mapToAnnouncementListDTO(rawAnnouncements, page, size, totalCount);
 };
+
+export const getAnnouncementService = async (announcementId: string) => {
+  if (!announcementId) {
+    throw new Error("announcementId가 누락되었습니다.");
+  }
+  const result = await getAnnouncementRepository(announcementId);
+  if (!result) {
+  throw new Error("Tip not found");
+  }
+  return mapToCreateAnnouncementDTO(result);
+};
+
 
 export const createAnnouncementService = async (data: any) => {
   if (!data.writer_id) {

--- a/src/tips/controllers/tip.controllers.ts
+++ b/src/tips/controllers/tip.controllers.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import {
   findTipList,
+  getTipService,
   createTipService,
   patchTipService,
   deleteTipService,
@@ -28,6 +29,23 @@ export const getTipList = async (
     return res.status(500).json({
       error: err.name || "InternalServerError",
       message: err.message || "팁 목록 조회 중 오류가 발생했습니다.",
+      statusCode: err.statusCode || 500,
+    });
+  }
+};
+
+// 팁 생성 - 관리자 인증 필요
+export const getTip = async (req: Request, res: Response) => {
+  try {
+    const result = await getTipService(req.params.tipId);
+    return res.success({
+      data: result,
+    });
+  } catch (err: any) {
+    console.error(err);
+    return res.status(500).json({
+      error: err.name || "InternalServerError",
+      message: err.message || "팁 조회 중 오류가 발생했습니다.",
       statusCode: err.statusCode || 500,
     });
   }

--- a/src/tips/repositories/tip.repository.ts
+++ b/src/tips/repositories/tip.repository.ts
@@ -14,6 +14,14 @@ export const findtips = async (page: number, size: number) => {
   });
 };
 
+export const getTipRepository = async (tipId: string) => {
+  const parsedTipId = parseInt(tipId, 10);
+
+  return await prisma.tip.findUnique({
+    where: { tip_id: parsedTipId },
+  });
+};
+
 export const createTipRepository = async (data: any) => {
   return await prisma.tip.create({
     data: {

--- a/src/tips/routes/tip.route.ts
+++ b/src/tips/routes/tip.route.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import {
   getTipList,
+  getTip,
   createTip,
   patchTip,
   deleteTip,
@@ -90,6 +91,9 @@ router.get("/", getTipList);
  *         description: 관리자 권한 없음
  */
 // 관리자만 접근 가능
+router.get("/:tipId/details", authenticateJwt, isAdmin, getTip);
+
+
 router.post("/", authenticateJwt, isAdmin, createTip);
 
 /**

--- a/src/tips/services/tip.service.ts
+++ b/src/tips/services/tip.service.ts
@@ -2,6 +2,7 @@ import { Tip } from "@prisma/client";
 import { mapToTipListDTO, mapToCreateTipDTO } from "../dtos/tip.dto";
 import {
   findtips,
+  getTipRepository,
   createTipRepository,
   updateTipRepository,
   removeTipRepository,
@@ -18,6 +19,18 @@ export const findTipList = async (rawPage?: string, rawSize?: string) => {
   const totalCount = rawTips.length;
 
   return mapToTipListDTO(rawTips, page, size, totalCount);
+};
+
+export const getTipService = async (tipId: string) => {
+  if (!tipId) {
+    throw new Error("tipId가 누락되었습니다.");
+  }
+  const result = await getTipRepository(tipId);
+  
+  if (!result) {
+  throw new Error("Tip not found");
+  }
+  return mapToCreateTipDTO(result);
 };
 
 export const createTipService = async (data: any) => {


### PR DESCRIPTION
프롬프트 팁 / 공지사항 상세정보 조회 구현

## 📌 기능 설명
- 프롬프트 팁 및 공지사항의 상세정보 조회 API가 누락되어 새로 작성하였습니다.

## 📌 구현 내용
- 프롬프트 팁 및 공지사항의 상세정보 조회

## 📌 구현 결과
<img width="617" height="787" alt="image" src="https://github.com/user-attachments/assets/aedc38fd-d101-4d2d-a093-8d8064196080" />

<img width="589" height="837" alt="image" src="https://github.com/user-attachments/assets/75f73342-f616-4ed4-a201-4a90675a242e" />

- 정상적으로 작동 확인 완료

## 📌 논의하고 싶은 점
