### PR TITLE
feat/#176 프롬프트 전체 조회 구현

### DIFF
--- a/src/prompts/controllers/prompt.controller.ts
+++ b/src/prompts/controllers/prompt.controller.ts
@@ -49,6 +49,22 @@ export const searchPrompts = async (req: Request, res: Response) => {
   }
 };
 
+export const getAllPrompts = async (req: Request, res: Response) => {
+  try {
+    const promptList = await promptService.getAllPrompts();
+    if (!promptList) {
+      return res.status(404).json({ message: "프롬프트가 존재하지 않습니다." });
+    }
+    return res.status(200).json({
+      statusCode: 200,
+      message: "프롬프트 전체 조회 성공",
+      data: promptList,
+    });
+  } catch (error) {
+    return errorHandler(error, req, res, () => {});
+  }
+}
+
 export const getPromptDetails = async (req: Request, res: Response) => {
   try {
     const { promptId } = req.params;

--- a/src/prompts/repositories/prompt.repository.ts
+++ b/src/prompts/repositories/prompt.repository.ts
@@ -74,6 +74,15 @@ export const searchPromptRepo = async (data: SearchPromptDto) => {
   return results;
 };
 
+export const getAllPromptRepo = async () => {
+  return await prisma.prompt.findMany({
+    include: {
+      images: {
+        select: { image_url: true },
+      },
+    },
+  });
+};
 
 export const getPromptDetailRepo = async (promptId: number) => {
   const prompt = await prisma.prompt.findUnique({

--- a/src/prompts/routes/prompt.route.ts
+++ b/src/prompts/routes/prompt.route.ts
@@ -67,6 +67,9 @@ const router = Router();
 // 프롬프트 검색 API
 router.get("/searches", promptController.searchPrompts);
 
+//프롬프트 전체 조회 API
+router.get("/", authenticateJwt, promptController.getAllPrompts);
+
 //프롬프트 상세 조회 API
 router.get("/:promptId/details", authenticateJwt, promptController.getPromptDetails);
 

--- a/src/prompts/services/prompt.service.ts
+++ b/src/prompts/services/prompt.service.ts
@@ -14,6 +14,10 @@ export const searchPrompts = async (dto: SearchPromptDto) => {
   return await promptRepository.searchPromptRepo(dto);
 };
 
+export const getAllPrompts = async () => {
+  return await promptRepository.getAllPromptRepo();
+}
+
 export const getPromptDetail = async (promptId: number) => {
   return await promptRepository.getPromptDetailRepo(promptId);
 }


### PR DESCRIPTION
프롬프트 전체 조회 구현

## 📌 기능 설명
프론트 파트의 요청으로 프롬프트 전체 조회 API를 새롭게 작성하였습니다.

## 📌 구현 내용
get | api/prompts  :  전체 프롬프트 조회 (비회원 가능, 토큰 여부 X)

## 📌 구현 결과
<img width="711" height="1029" alt="image" src="https://github.com/user-attachments/assets/67980797-b142-4b38-8d5d-35774ee9882e" />


## 📌 논의하고 싶은 점