### PR TITLE
feat: 소셜 로그인 토큰 교환 API 구현

### DIFF
--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -221,7 +221,7 @@ class AuthController {
     }
   }
 
-  async kakakToken(req: Request, res: Response) {
+  async kakaoToken(req: Request, res: Response) {
     try {
       const { code } = req.body;
 

--- a/src/auth/routes/auth.route.ts
+++ b/src/auth/routes/auth.route.ts
@@ -277,6 +277,410 @@ router.post("/complete-signup", AuthController.completeSignup);
 
 /**
  * @swagger
+ * /api/auth/kakao/token:
+ *   post:
+ *     summary: 카카오 로그인 토큰 교환
+ *     description: 프론트엔드에서 받은 카카오 인증코드로 JWT 토큰을 발급받습니다.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - code
+ *             properties:
+ *               code:
+ *                 type: string
+ *                 description: 카카오 OAuth 인증코드
+ *                 example: "abc123def456ghi789"
+ *     responses:
+ *       200:
+ *         description: 카카오 로그인 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 카카오 로그인이 완료되었습니다.
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     access_token:
+ *                       type: string
+ *                       description: JWT 액세스 토큰 (3시간 유효)
+ *                       example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+ *                     refresh_token:
+ *                       type: string
+ *                       description: JWT 리프레시 토큰 (14일 유효)
+ *                       example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+ *                     user:
+ *                       type: object
+ *                       properties:
+ *                         user_id:
+ *                           type: integer
+ *                           description: 사용자 고유 ID
+ *                           example: 1
+ *                         name:
+ *                           type: string
+ *                           description: 사용자 이름 (카카오는 제공하지 않아 빈 문자열)
+ *                           example: ""
+ *                         nickname:
+ *                           type: string
+ *                           description: 카카오 닉네임
+ *                           example: "카카오닉네임"
+ *                         email:
+ *                           type: string
+ *                           description: 카카오 계정 이메일
+ *                           example: "user@kakao.com"
+ *                         social_type:
+ *                           type: string
+ *                           description: 소셜 로그인 타입
+ *                           example: "KAKAO"
+ *                         status:
+ *                           type: boolean
+ *                           description: 계정 활성화 상태
+ *                           example: true
+ *                         role:
+ *                           type: string
+ *                           description: 사용자 역할
+ *                           example: "USER"
+ *                         created_at:
+ *                           type: string
+ *                           format: date-time
+ *                           description: 계정 생성 시간
+ *                         updated_at:
+ *                           type: string
+ *                           format: date-time
+ *                           description: 계정 정보 수정 시간
+ *                 statusCode:
+ *                   type: number
+ *                   example: 200
+ *       400:
+ *         description: 잘못된 요청 데이터
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "BadRequest"
+ *                 message:
+ *                   type: string
+ *                   example: "인증코드가 필요합니다."
+ *                 statusCode:
+ *                   type: number
+ *                   example: 400
+ *       401:
+ *         description: 인증 실패
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Unauthorized"
+ *                 message:
+ *                   type: string
+ *                   example: "카카오 인증에 실패했습니다."
+ *                 statusCode:
+ *                   type: number
+ *                   example: 401
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "InternalServerError"
+ *                 message:
+ *                   type: string
+ *                   example: "알 수 없는 오류가 발생했습니다."
+ *                 statusCode:
+ *                   type: number
+ *                   example: 500
+ */
+router.post("/kakao/token", AuthController.kakaoToken);
+
+/**
+ * @swagger
+ * /api/auth/google/token:
+ *   post:
+ *     summary: 구글 로그인 토큰 교환
+ *     description: 프론트엔드에서 받은 구글 인증코드로 JWT 토큰을 발급받습니다.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - code
+ *             properties:
+ *               code:
+ *                 type: string
+ *                 description: 구글 OAuth 인증코드
+ *                 example: "4/0AfJohXn..."
+ *     responses:
+ *       200:
+ *         description: 구글 로그인 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 구글 로그인이 완료되었습니다.
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     access_token:
+ *                       type: string
+ *                       description: JWT 액세스 토큰 (3시간 유효)
+ *                       example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+ *                     refresh_token:
+ *                       type: string
+ *                       description: JWT 리프레시 토큰 (14일 유효)
+ *                       example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+ *                     user:
+ *                       type: object
+ *                       properties:
+ *                         user_id:
+ *                           type: integer
+ *                           description: 사용자 고유 ID
+ *                           example: 1
+ *                         name:
+ *                           type: string
+ *                           description: 구글 계정 이름
+ *                           example: "홍길동"
+ *                         nickname:
+ *                           type: string
+ *                           description: 구글 계정 닉네임
+ *                           example: "길동이"
+ *                         email:
+ *                           type: string
+ *                           description: 구글 계정 이메일
+ *                           example: "user@gmail.com"
+ *                         social_type:
+ *                           type: string
+ *                           description: 소셜 로그인 타입
+ *                           example: "GOOGLE"
+ *                         status:
+ *                           type: boolean
+ *                           description: 계정 활성화 상태
+ *                           example: true
+ *                         role:
+ *                           type: string
+ *                           description: 사용자 역할
+ *                           example: "USER"
+ *                         created_at:
+ *                           type: string
+ *                           format: date-time
+ *                           description: 계정 생성 시간
+ *                         updated_at:
+ *                           type: string
+ *                           format: date-time
+ *                           description: 계정 정보 수정 시간
+ *                 statusCode:
+ *                   type: number
+ *                   example: 200
+ *       400:
+ *         description: 잘못된 요청 데이터
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "BadRequest"
+ *                 message:
+ *                   type: string
+ *                   example: "인증코드가 필요합니다."
+ *                 statusCode:
+ *                   type: number
+ *                   example: 400
+ *       401:
+ *         description: 인증 실패
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Unauthorized"
+ *                 message:
+ *                   type: string
+ *                   example: "구글 인증에 실패했습니다."
+ *                 statusCode:
+ *                   type: number
+ *                   example: 401
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "InternalServerError"
+ *                 message:
+ *                   type: string
+ *                   example: "알 수 없는 오류가 발생했습니다."
+ *                 statusCode:
+ *                   type: number
+ *                   example: 500
+ */
+router.post("/google/token", AuthController.googleToken);
+
+/**
+ * @swagger
+ * /api/auth/naver/token:
+ *   post:
+ *     summary: 네이버 로그인 토큰 교환
+ *     description: 프론트엔드에서 받은 네이버 인증코드로 JWT 토큰을 발급받습니다.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - code
+ *             properties:
+ *               code:
+ *                 type: string
+ *                 description: 네이버 OAuth 인증코드
+ *                 example: "abc123def456ghi789"
+ *     responses:
+ *       200:
+ *         description: 네이버 로그인 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 네이버 로그인이 완료되었습니다.
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     access_token:
+ *                       type: string
+ *                       description: JWT 액세스 토큰 (3시간 유효)
+ *                       example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+ *                     refresh_token:
+ *                       type: string
+ *                       description: JWT 리프레시 토큰 (14일 유효)
+ *                       example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+ *                     user:
+ *                       type: object
+ *                       properties:
+ *                         user_id:
+ *                           type: integer
+ *                           description: 사용자 고유 ID
+ *                           example: 1
+ *                         name:
+ *                           type: string
+ *                           description: 네이버 계정 이름
+ *                           example: "홍길동"
+ *                         nickname:
+ *                           description: 네이버 계정 닉네임
+ *                           example: "길동이"
+ *                         email:
+ *                           type: string
+ *                           description: 네이버 계정 이메일
+ *                           example: "user@naver.com"
+ *                         social_type:
+ *                           type: string
+ *                           description: 소셜 로그인 타입
+ *                           example: "NAVER"
+ *                         status:
+ *                           type: boolean
+ *                           description: 계정 활성화 상태
+ *                           example: true
+ *                         role:
+ *                           type: string
+ *                           description: 사용자 역할
+ *                           example: "USER"
+ *                         created_at:
+ *                           type: string
+ *                           format: date-time
+ *                           description: 계정 생성 시간
+ *                         updated_at:
+ *                           type: string
+ *                           format: date-time
+ *                           description: 계정 정보 수정 시간
+ *                 statusCode:
+ *                   type: number
+ *                   example: 200
+ *       400:
+ *         description: 잘못된 요청 데이터
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "BadRequest"
+ *                 message:
+ *                   type: string
+ *                   example: "인증코드가 필요합니다."
+ *                 statusCode:
+ *                   type: number
+ *                   example: 400
+ *       401:
+ *         description: 인증 실패
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Unauthorized"
+ *                 message:
+ *                   type: string
+ *                   example: "네이버 인증에 실패했습니다."
+ *                 statusCode:
+ *                   type: number
+ *                   example: 401
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "InternalServerError"
+ *                 message:
+ *                   type: string
+ *                   example: "알 수 없는 오류가 발생했습니다."
+ *                 statusCode:
+ *                   type: number
+ *                   example: 500
+ */
+router.post("/naver/token", AuthController.naverToken);
+
+/**
+ * @swagger
  * /api/auth/logout:
  *   get:
  *     summary: 로그아웃


### PR DESCRIPTION
## 📌 기능 설명
프론트엔드 연동을 위한 소셜 로그인 토큰 교환 API를 구현했습니다. 기존 Passport 기반 리다이렉트 방식에서 프론트엔드 주도 방식으로 변경하여, 프론트엔드에서 인증코드를 받아 백엔드로 전송하는 구조로 개선했습니다.

## 📌 구현 내용

### **새로운 API 엔드포인트 추가**
- `POST /api/auth/kakao/token` - 카카오 인증코드로 토큰 교환
- `POST /api/auth/google/token` - 구글 인증코드로 토큰 교환  
- `POST /api/auth/naver/token` - 네이버 인증코드로 토큰 교환

### **소셜 로그인 플로우 구현**
- **카카오**: 2단계 로그인 (인증 → 추가 정보 입력)
  - 1단계: 카카오 인증 후 임시 사용자 생성 (name 필드 빈 문자열)
  - 2단계: 프론트엔드에서 name 입력 후 `complete-signup` API 호출
- **구글/네이버**: 1단계 로그인 (인증 → 바로 완료)

### **CompleteSignupDto 최적화**
- `description`, `sns_url` 필드 제거 (소셜 로그인 시 불필요)
- 카카오 로그인 전용으로 단순화
- `name`, `nickname`, `email` 필드만 유지

### **Prisma 스키마 요구사항 충족**
- `name` 필드가 필수인데 카카오 로그인 시 빈 문자열로 설정하여 스키마 위반 방지
- 소셜 로그인 후 `complete-signup`에서 실제 name 값으로 업데이트

### **Swagger API 문서화**
- 각 소셜 로그인 API에 대한 상세한 Swagger 문서 작성
- 요청/응답 스키마, 에러 케이스, 예시 데이터 포함
- 프론트엔드 개발자를 위한 명확한 API 명세서 제공

## 📌 구현 결과

### **API 응답 예시**
```json
// POST /api/auth/kakao/token 응답
{
  "message": "카카오 로그인이 완료되었습니다.",
  "data": {
    "access_token": "JWT토큰",
    "refresh_token": "리프레시토큰", 
    "user": {
      "user_id": 1,
      "email": "user@kakao.com",
      "nickname": "카카오닉네임",
      "name": "",  // 빈 문자열 (추가 입력 필요)
      "social_type": "KAKAO",
      "status": true,
      "role": "USER"
    }
  },
  "statusCode": 200
}

// POST /api/auth/complete-signup 응답
{
  "accessToken": "JWT토큰",
  "refreshToken": "리프레시토큰",
  "user": {
    "user_id": 1,
    "name": "홍길동",  // 이제 실제 이름
    "nickname": "카카오닉네임",
    "email": "user@kakao.com"
  }
}
```

### **Swagger 문서 생성**
- `/docs` 페이지에서 소셜 로그인 API 명세서 확인 가능
- 각 API의 요청/응답 구조, 에러 케이스, 예시 데이터 제공
- 프론트엔드 개발자가 쉽게 API를 이해하고 테스트할 수 있음

### **프론트엔드 연동 가이드 제공**
- 환경별 콜백 URL 분기 방법
- 소셜 로그인 플로우 설명
- 환경변수 설정 가이드

## 📌 논의하고 싶은 점

