### PR TITLE
Fix/#197

### DIFF
--- a/src/members/controllers/member.controller.ts
+++ b/src/members/controllers/member.controller.ts
@@ -585,21 +585,13 @@ export class MemberController {
     next: NextFunction
   ): Promise<void> {
     try {
-      const userId = (req.user as any).user_id;
-
-      // 관리자 권한 확인
-      const user = await this.memberService.getMemberById(userId, userId);
-      if (user.role !== "ADMIN") {
-        throw new AppError("관리자만 접근할 수 있습니다.", 403, "Forbidden");
-      }
-
       const page = parseInt(req.query.page as string) || 1;
       const limit = parseInt(req.query.limit as string) || 20;
 
       const result = await this.memberService.getAllMembers(page, limit);
 
       res.status(200).json({
-        message: "전체 회원 조회 완료",
+        message: "인기 유저 조회 완료",
         data: result,
         statusCode: 200,
       });

--- a/src/members/controllers/member.controller.ts
+++ b/src/members/controllers/member.controller.ts
@@ -591,7 +591,7 @@ export class MemberController {
       const result = await this.memberService.getAllMembers(page, limit);
 
       res.status(200).json({
-        message: "인기 유저 조회 완료",
+        message: "전체 회원 조회 완료",
         data: result,
         statusCode: 200,
       });

--- a/src/members/routes/member.route.ts
+++ b/src/members/routes/member.route.ts
@@ -593,11 +593,9 @@ router.delete(
  * @swagger
  * /api/members:
  *   get:
- *     summary: 전체 회원 조회
- *     description: 관리자만 접근 가능한 전체 회원 목록 조회 API
+ *     summary: 인기 유저 조회 (공개)
+ *     description: 홈페이지 인기 유저 표시용 공개 API
  *     tags: [Member]
- *     security:
- *       - jwt: []
  *     parameters:
  *       - in: query
  *         name: page
@@ -667,38 +665,7 @@ router.delete(
  *                 statusCode:
  *                   type: integer
  *                   example: 200
- *       401:
- *         description: 인증 실패
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 error:
- *                   type: string
- *                   example: Unauthorized
- *                 message:
- *                   type: string
- *                   example: 로그인이 필요합니다.
- *                 statusCode:
- *                   type: integer
- *                   example: 401
- *       403:
- *         description: 권한 없음
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 error:
- *                   type: string
- *                   example: Forbidden
- *                 message:
- *                   type: string
- *                   example: 관리자만 접근할 수 있습니다.
- *                 statusCode:
- *                   type: integer
- *                   example: 403
+
  *       500:
  *         description: 서버 오류
  *         content:
@@ -716,11 +683,7 @@ router.delete(
  *                   type: integer
  *                   example: 500
  */
-// 전체 회원 조회 API
-router.get(
-  "/",
-  authenticateJwt,
-  memberController.getAllMembers.bind(memberController)
-);
+// 인기 유저 조회 API (공개)
+router.get("/", memberController.getAllMembers.bind(memberController));
 
 export default router;

--- a/src/members/routes/member.route.ts
+++ b/src/members/routes/member.route.ts
@@ -593,8 +593,8 @@ router.delete(
  * @swagger
  * /api/members:
  *   get:
- *     summary: 인기 유저 조회 (공개)
- *     description: 홈페이지 인기 유저 표시용 공개 API
+ *     summary: 전체 회원 조회 (공개)
+ *     description: 홈페이지 인기 유저 표시용으로 전체 회원을 조회하는 공개 API
  *     tags: [Member]
  *     parameters:
  *       - in: query
@@ -665,7 +665,6 @@ router.delete(
  *                 statusCode:
  *                   type: integer
  *                   example: 200
-
  *       500:
  *         description: 서버 오류
  *         content:
@@ -683,7 +682,7 @@ router.delete(
  *                   type: integer
  *                   example: 500
  */
-// 인기 유저 조회 API (공개)
+// 전체 회원 조회 API (공개)
 router.get("/", memberController.getAllMembers.bind(memberController));
 
 export default router;

--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -62,14 +62,16 @@ export class MemberService {
       memberId
     );
 
-    return followers.map((f) => ({
-      follow_id: f.follow_id,
-      follower_id: f.follower_id,
-      nickname: f.follower.nickname,
-      email: f.follower.email,
-      created_at: f.created_at,
-      updated_at: f.updated_at,
-    }));
+    return followers
+      .filter((f) => f.follower) // null 체크
+      .map((f) => ({
+        follow_id: f.follow_id,
+        follower_id: f.follower_id,
+        nickname: f.follower!.nickname,
+        email: f.follower!.email,
+        created_at: f.created_at,
+        updated_at: f.updated_at,
+      }));
   }
 
   async getFollowings(memberId: number) {
@@ -82,14 +84,16 @@ export class MemberService {
       memberId
     );
 
-    return followings.map((f) => ({
-      follow_id: f.follow_id,
-      following_id: f.following_id,
-      nickname: f.following.nickname,
-      email: f.following.email,
-      created_at: f.created_at,
-      updated_at: f.updated_at,
-    }));
+    return followings
+      .filter((f) => f.following) // null 체크
+      .map((f) => ({
+        follow_id: f.follow_id,
+        following_id: f.following_id,
+        nickname: f.following!.nickname,
+        email: f.following!.email,
+        created_at: f.created_at,
+        updated_at: f.updated_at,
+      }));
   }
 
   async getMemberPrompts(memberId: number, cursor?: number, limit?: number) {
@@ -117,6 +121,7 @@ export class MemberService {
       created_at: member.created_at,
       updated_at: member.updated_at,
       status: member.status ? 1 : 0,
+      role: member.role,
     };
   }
 


### PR DESCRIPTION
## 📌 기능 설명
이 PR은 PromptPlace 백엔드의 TypeScript 빌드 오류를 해결하고, 전체 회원 조회 API를 공개 API로 변경하는 작업을 다룹니다.

## 📌  구현 내용

### **1. TypeScript 빌드 오류 해결**
- **Inquiry 모듈**: `include` 관계 쿼리 대신 별도 쿼리로 sender/receiver 정보 조회
- **Member 모듈**: `include` 관계 쿼리 대신 별도 쿼리로 follower/following 정보 조회
- **Prisma 스키마 변경 없이** 기존 테이블들을 조합하여 데이터 조회

### **2. 전체 회원 조회 API 공개화**
- **권한 체크 제거**: 관리자 전용에서 공개 API로 변경
- **인증 미들웨어 제거**: `authenticateJwt` 미들웨어 제거
- **토큰 불필요**: 로그인 없이 접근 가능
- **홈페이지 인기 유저 표시용**으로 활용

### **3. API 응답 및 문서 개선**
- **응답 메시지**: "전체 회원 조회 완료"로 통일
- **Swagger 문서**: 공개 API에 맞게 401/403 에러 응답 제거
- **API 설명**: "홈페이지 인기 유저 표시용으로 전체 회원을 조회하는 공개 API"

## 📌 구현 결과

### **해결된 빌드 오류들**
```
✅ src/inquiries/repositories/inquiry.repository.ts
✅ src/members/repositories/member.repository.ts
✅ src/members/services/member.service.ts
✅ src/members/controllers/member.controller.ts
```

### **API 변경 사항**
- **기존**: `GET /api/members` (관리자 전용, 토큰 필요)
- **변경**: `GET /api/members` (공개, 토큰 불필요)
- **응답**: 전체 회원 목록 + 팔로워 수 + 페이지네이션 정보

### **데이터 조회 방식 개선**
```typescript
// Before: Prisma include로 관계 데이터 조회 (스키마 관계 없음)
include: { sender: { select: { nickname: true } } }

// After: 별도 쿼리로 데이터 조회 후 조합
const sender = await prisma.user.findUnique({
  where: { user_id: inquiry.sender_id },
  select: { nickname: true }
});
```

## 📌 논의하고 싶은 점
