### PR TITLE
fix: inquiries.service에서 나온 에러 해결

### DIFF
--- a/src/inquiries/repositories/inquiry.repository.ts
+++ b/src/inquiries/repositories/inquiry.repository.ts
@@ -24,6 +24,11 @@ export class InquiryRepository {
       }),
     ]);
 
+    // sender나 receiver가 null이면 에러 처리
+    if (!sender || !receiver) {
+      throw new Error(`사용자 정보를 찾을 수 없습니다. sender: ${sender ? 'found' : 'not found'}, receiver: ${receiver ? 'found' : 'not found'}`);
+    }
+
     return {
       ...inquiry,
       sender,
@@ -96,6 +101,12 @@ export class InquiryRepository {
           where: { user_id: inquiry.sender_id },
           select: { nickname: true },
         });
+        
+        // sender가 null이면 에러 처리
+        if (!sender) {
+          throw new Error(`발신자 정보를 찾을 수 없습니다. sender_id: ${inquiry.sender_id}`);
+        }
+        
         return {
           ...inquiry,
           sender,

--- a/src/inquiries/services/inquiry.service.ts
+++ b/src/inquiries/services/inquiry.service.ts
@@ -137,16 +137,23 @@ export class InquiryService {
       type
     );
 
-    return inquiries.map((inquiry) => ({
-      inquiry_id: inquiry.inquiry_id,
-      sender_id: inquiry.sender_id,
-      sender_nickname: inquiry.sender.nickname,
-      type: inquiry.type,
-      status: inquiry.status,
-      title: inquiry.title,
-      created_at: inquiry.created_at,
-      updated_at: inquiry.updated_at,
-    }));
+    return inquiries.map((inquiry) => {
+      // sender가 null일 수 있으므로 안전하게 처리
+      if (!inquiry.sender) {
+        throw new AppError("발신자 정보를 찾을 수 없습니다.", 500, "InternalServerError");
+      }
+
+      return {
+        inquiry_id: inquiry.inquiry_id,
+        sender_id: inquiry.sender_id,
+        sender_nickname: inquiry.sender.nickname,
+        type: inquiry.type,
+        status: inquiry.status,
+        title: inquiry.title,
+        created_at: inquiry.created_at,
+        updated_at: inquiry.updated_at,
+      };
+    });
   }
 
   async deleteInquiry(userId: number, inquiryId: number) {


### PR DESCRIPTION
## 📌 기능 설명
TypeScript 컴파일 에러를 해결하여 코드의 타입 안전성을 향상시키는 수정 사항입니다.

## 📌 구현 내용
**문제 상황:**
- `src/inquiries/services/inquiry.service.ts`에서 `inquiry.sender`와 `inquiry.receiver`가 `null`일 수 있다는 TypeScript 에러 발생
- 에러 발생 위치: 53번째, 55번째, 143번째 줄

**해결 방법:**
1. **Repository 레벨에서 null 체크 추가**
   - `findInquiryById`: `sender`와 `receiver`가 null인 경우 Error를 던지도록 수정
   - `findReceivedInquiries`: `sender`가 null인 경우 Error를 던지도록 수정

2. **Service 레벨에서 null 체크 추가**
   - `getReceivedInquiries`: `sender`가 null인 경우 `AppError`를 던지도록 수정

**수정된 파일:**
- `src/inquiries/repositories/inquiry.repository.ts`
- `src/inquiries/services/inquiry.service.ts`

## 📌 구현 결과
- ✅ TypeScript 컴파일 에러 해결
- ✅ `inquiry.sender`와 `inquiry.receiver`의 null 가능성 제거
- ✅ 타입 안전성 향상
- ✅ 런타임에서 사용자 정보 누락 시 명확한 에러 메시지 제공

**에러 메시지 예시:**
- "사용자 정보를 찾을 수 없습니다. sender: not found, receiver: not found"
- "발신자 정보를 찾을 수 없습니다. sender_id: {id}"

## 📌 논의하고 싶은 점