### PR TITLE
Feat: 결제 내역 조회 API 구현

### DIFF
--- a/src/purchases/controller/purchase.controller.ts
+++ b/src/purchases/controller/purchase.controller.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from "express";
+import { PurchaseHistoryService } from "../services/purchase.service";
+import { PurchaseHistoryResponseDTO } from "../dtos/purchase.dto";
+
+export const PurchaseHistoryController = {
+    async list(req: Request, res: Response, next: NextFunction) {
+        try {
+            const userId= (req.user as any).user_id;
+            const result: PurchaseHistoryResponseDTO = await PurchaseHistoryService.list(userId);
+            res.status(result.statusCode).json(result);
+        } catch (err) {
+            next(err);
+        }
+    }
+}

--- a/src/purchases/dtos/purchase.dto.ts
+++ b/src/purchases/dtos/purchase.dto.ts
@@ -1,0 +1,13 @@
+export interface PurchaseHistoryItemDTO {
+    prompt_id: number;
+    title: string;
+    price: number;
+    seller_nickname: string;
+    pg: 'kakaopay' | 'tosspay';
+}
+
+export interface PurchaseHistoryResponseDTO {
+    message: string;
+    purchases: PurchaseHistoryItemDTO[];
+    statusCode: number;
+}

--- a/src/purchases/repositories/purchase.request.repository.ts
+++ b/src/purchases/repositories/purchase.request.repository.ts
@@ -72,4 +72,28 @@ export const PurchaseRepository = {
       },
     });
   },
+
+  findSucceededByUser(userId: number) {
+    return prisma.purchase.findMany({
+      where: {
+        user_id: userId,
+        payment: { is: { status: 'Succeed'}},
+      },
+      include: {
+        prompt: {
+          select: {
+            prompt_id: true,
+            title: true,
+            user: { select: { nickname: true}},
+          },
+        },
+        payment: {
+          select: {
+            provider: true,
+          },
+        },
+      },
+      orderBy: { created_at: 'desc'},
+    })
+  }
 };

--- a/src/purchases/routes/purchase.request.route.ts
+++ b/src/purchases/routes/purchase.request.route.ts
@@ -2,10 +2,12 @@ import { Router } from 'express';
 import { PurchaseCompleteController } from '../controller/purchase.complete.controller';
 import { authenticateJwt } from '../../config/passport';
 import { PurchaseRequestController } from '../controller/purchase.request.controller';
+import { PurchaseHistoryController } from '../controller/purchase.controller';
 
 const router = Router();
 
 router.post('/requests', authenticateJwt, PurchaseRequestController.requestPurchase);
 router.post('/complete', authenticateJwt, PurchaseCompleteController.completePurchase);
+router.get('/', authenticateJwt, PurchaseHistoryController.list);
 
 export default router;

--- a/src/purchases/services/purchase.service.ts
+++ b/src/purchases/services/purchase.service.ts
@@ -1,0 +1,30 @@
+import { PurchaseRepository } from "../repositories/purchase.request.repository";
+import { PurchaseHistoryItemDTO, PurchaseHistoryResponseDTO } from "../dtos/purchase.dto";
+
+function mapPgProvider(pg: string | undefined): 'kakaopay' | 'tosspay' {
+  const src = (pg || '').toLowerCase();
+  if (src.includes('kakaopay')) return 'kakaopay';
+  if (src.includes('tosspay')) return 'tosspay';
+  return 'tosspay';
+}
+
+export const PurchaseHistoryService = {
+    async list(userId: number): Promise<PurchaseHistoryResponseDTO> {
+        const rows = await PurchaseRepository.findSucceededByUser(userId);
+    
+        const purchases: PurchaseHistoryItemDTO[] = rows.map((r) => ({
+            prompt_id: r.prompt.prompt_id,
+            title: r.prompt.title,
+            price:  r.amount,
+            purchased_at: r.created_at.toISOString(),
+            seller_nickname: r.prompt.user.nickname,
+            pg: mapPgProvider(r.payment?.provider),
+        }));
+
+        return {
+            message: "결제 내역 조회 성공",
+            purchases,
+            statusCode: 200,
+        }
+    }
+}


### PR DESCRIPTION
## 📌 기능 설명
사용자의 결제 내역을 조회하는 API를 구현했습니다.
해당 API는 인증된 사용자의 결제 히스토리를 조회하며, 프롬프트 정보와 판매자 정보를 함께 반환합니다.

## 📌 구현 내용
- **GET /api/purchases** 엔드포인트 추가
  - 요청 헤더의 `Authorization: Bearer {access_token}`을 통해 사용자 인증
  - 사용자가 구매한 프롬프트 목록과 결제 정보 조회
- **응답 형식**
  ```json
  {
    "message": "결제 내역 조회 성공",
    "purchases": [
      {
        "prompt_id": 1024,
        "title": "시장조사 프롬프트",
        "price": 3000,
        "purchased_at": "2025-07-04T09:30:00.000Z",
        "seller_nickname": "분석가123",
        "pg": "kakaopay"
      }
    ],
    "statusCode": 200
  }

## 📌 구현 결과
<img width="1392" height="873" alt="image" src="https://github.com/user-attachments/assets/faef1208-97a3-49e8-a6b0-60a939ffd74b" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->