### PR TITLE
Feat: 출금 가능 금액 조회 API 구현

### DIFF
--- a/src/withdrawals/controllers/withdrawal.available.controller.ts
+++ b/src/withdrawals/controllers/withdrawal.available.controller.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from 'express';
+import { WithdrawalAvailableService } from '../services/withdrawal.available.service';
+
+export const WithdrawalAvailableController = {
+  async getAvailable(req: Request, res: Response) {
+    const user = req.user;
+    if (!user) {
+      return res.status(401).json({
+        error: 'Unauthorized',
+        message: '로그인이 필요합니다.',
+        statusCode: 401,
+      });
+    }
+
+    try {
+      const result = await WithdrawalAvailableService.getAvailableAmount(user.user_id);
+      return res.status(200).json(result);
+    } catch (e: any) {
+      return res.status(500).json({
+        error: 'InternalServerError',
+        message: '서버 오류가 발생했습니다.',
+        statusCode: 500,
+      });
+    }
+  }
+};

--- a/src/withdrawals/dtos/withdrawal.available.dto.ts
+++ b/src/withdrawals/dtos/withdrawal.available.dto.ts
@@ -1,0 +1,11 @@
+export interface WithdrawalAvailableResponseDto {
+  message: string;
+  available_amount: number;
+  statusCode: number;
+}
+
+export interface ErrorResponseDto {
+  error: string;
+  message: string;
+  statusCode: number;
+}

--- a/src/withdrawals/repositories/withdrawal.repository.ts
+++ b/src/withdrawals/repositories/withdrawal.repository.ts
@@ -11,7 +11,7 @@ export const WithdrawalRepository = {
 
   async getUserTotalWithdrawn(userId: number): Promise<number> {
     const result = await prisma.withdrawRequest.aggregate({
-      where: { user_id: userId },
+      where: { user_id: userId, status: { in: ['Pending', 'Succeed'] } }, 
       _sum: { amount: true },
     });
     return result._sum.amount ?? 0;

--- a/src/withdrawals/routes/withdrawal.route.ts
+++ b/src/withdrawals/routes/withdrawal.route.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import { WithdrawalController } from '../controllers/withdrawal.controller';
+import { WithdrawalAvailableController } from '../controllers/withdrawal.available.controller';
 import { authenticateJwt } from '../../config/passport';
 
 const router = Router();
 
 router.post('/withdrawals', authenticateJwt, WithdrawalController.requestWithdrawal);
+router.get('/withdrawals/available', authenticateJwt, WithdrawalAvailableController.getAvailable);
 
 export default router;

--- a/src/withdrawals/services/withdrawal.available.service.ts
+++ b/src/withdrawals/services/withdrawal.available.service.ts
@@ -1,0 +1,17 @@
+import { WithdrawalRepository } from "../repositories/withdrawal.repository";
+import { WithdrawalAvailableResponseDto } from "../dtos/withdrawal.available.dto";
+
+export const WithdrawalAvailableService = {
+  async getAvailableAmount(userId: number): Promise<WithdrawalAvailableResponseDto> {
+    const totalEarnings = await WithdrawalRepository.getUserTotalEarnings(userId);
+    const totalWithdrawnOrPending = await WithdrawalRepository.getUserTotalWithdrawn(userId);
+
+    const available = Math.max(0, totalEarnings - totalWithdrawnOrPending);
+
+    return {
+      message: '출금 가능 금액 조회 성공',
+      available_amount: available,
+      statusCode: 200,
+    };
+    }
+};

--- a/src/withdrawals/services/withdrawal.service.ts
+++ b/src/withdrawals/services/withdrawal.service.ts
@@ -6,7 +6,7 @@ export const WithdrawalService = {
     const { amount } = dto;
 
     // 1. 최소 출금 금액 확인
-    if (amount < 1000) {
+    if (amount < 10000) {
       throw {
         statusCode: 400,
         error: 'InvalidWithdrawalAmount',


### PR DESCRIPTION
## 📌 기능 설명
로그인한 사용자의 **출금 가능 금액**을 조회하는 API를 추가했습니다.
`GET /api/settlements/withdrawals/available` 엔드포인트를 통해 정산 완료 금액에서 이미 출금 요청(대기 + 완료)된 금액을 제외한 값을 반환합니다.

* 인증: `Authorization: Bearer {access_token}`
* 응답:

  ```json
  {
    "message": "출금 가능 금액 조회 성공",
    "available_amount": 12345,
    "statusCode": 200
  }
  ```

## 📌 구현 내용
* **엔드포인트**

  * `GET /api/settlements/withdrawals/available`
  * 인증 미들웨어 적용(미인증 시 `401 Unauthorized`)
* **계산 로직**

  * 정산 합계: `Settlement`에서 `status = 'SUCCEED'` 인 레코드의 `amount` 합계
  * 출금 합계: `WithdrawRequest`에서 `status IN ('PENDING', 'SUCCEED')` 인 레코드의 `amount` 합계
  * `available = max(0, 정산합계 - 출금합계)`로 산출(음수 방지)
* **레이어드 구조**

  * `dtos/withdrawalAvailable.dto.ts`: 응답 DTO 정의
  * `repositories/withdrawal.repository.ts`:

    * `getUserTotalEarnings(userId)` — 완료된 정산 합계 조회
    * `getUserTotalWithdrawn(userId)` — 대기/완료 상태의 출금 합계 조회
  * `services/withdrawalAvailable.service.ts`: 가용 금액 계산 비즈니스 로직
  * `controllers/withdrawalAvailable.controller.ts`: 인증 검사 및 응답 반환
  * `routes/withdrawal.route.ts`: `GET /withdrawals/available` 라우트 추가
* **에러 처리**

  * 미인증: `401 Unauthorized`
  * 서버 오류: `500 Internal Server Error`

## 📌 구현 결과
<img width="1146" height="623" alt="image" src="https://github.com/user-attachments/assets/ef9ac2fc-5bcc-43c9-bc4e-6e6a2d509154" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->