### PR TITLE
[FIX]: 수신자와 송신자 인자 전달 순서 해결

### DIFF
--- a/src/inquiries/services/inquiry.service.ts
+++ b/src/inquiries/services/inquiry.service.ts
@@ -25,9 +25,9 @@ export class InquiryService {
       senderId,
       createInquiryDto
     );
-
+ 
     // 새 문의 알림 이벤트 발생
-    eventBus.emit("inquiry.created", senderId, receiver.user_id);
+    eventBus.emit("inquiry.created", receiver.user_id, senderId);
 
     return inquiry;
   }

--- a/src/notifications/listeners/notification.listener.ts
+++ b/src/notifications/listeners/notification.listener.ts
@@ -40,7 +40,7 @@ eventBus.on('follow.created', async (followerId: number, followingId: number) =>
 eventBus.on('inquiry.created', async (receiverId: number, senderId: number) => {
   try {
     await createInquiryNotification(receiverId, senderId);
-  } catch (err) {
+  } catch (err) { 
     console.error("[알림 리스너 오류]: 새로운 문의 알림 생성 실패", err);
   }
 });


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
inquiry.service()에서 이벤트 알림 호출 인자 순서를 원래 함수의 인자 순서에 맞게 수정했습니다. 
기존:   `eventBus.emit("inquiry.created", senderId, receiver.user_id);`
수정 후:  `eventBus.emit("inquiry.created", receiver.user_id, senderId);`

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->