### PR TITLE
Fix: 출금 요청 로직 수정

### DIFF
--- a/prisma/migrations/20250814_baseline_from_prod/migration.sql
+++ b/prisma/migrations/20250814_baseline_from_prod/migration.sql
@@ -467,4 +467,3 @@ ALTER TABLE `UserSNS` ADD CONSTRAINT `UserSNS_user_id_fkey` FOREIGN KEY (`user_i
 
 -- AddForeignKey
 ALTER TABLE `WithdrawRequest` ADD CONSTRAINT `WithdrawRequest_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `User`(`user_id`) ON DELETE RESTRICT ON UPDATE CASCADE;
-

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,10 +19,10 @@ model User {
   updated_at        DateTime                   @updatedAt
   role              Role                       @default(USER)
   announcements     Announcement[]
+  receivedMessages  Message[]                  @relation("ReceivedMessages")
+  sentMessages      Message[]                  @relation("SentMessages")
   sentNotifications Notification[]             @relation("ActorNotifications")
   notifications     Notification[]             @relation("UserNotifications")
-  sentMessages     Message[] @relation("SentMessages")
-  receivedMessages Message[] @relation("ReceivedMessages")
   subscribers       NotificationSubscription[] @relation("NotificationTargetPrompter")
   subscriptions     NotificationSubscription[] @relation("NotificationSubscriber")
   prompts           Prompt[]
@@ -112,9 +112,9 @@ model Tip {
   title      String
   content    String   @db.Text
   is_visible Boolean
-  file_url        String?  @db.VarChar(255)
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
+  file_url   String?  @db.VarChar(255)
   writer     User     @relation(fields: [writer_id], references: [user_id])
 
   @@index([writer_id], map: "Tip_writer_id_fkey")
@@ -161,9 +161,8 @@ model Message {
   is_deleted  Boolean   @default(false)
   created_at  DateTime  @default(now())
   updated_at  DateTime  @updatedAt
-
-  sender   User @relation("SentMessages", fields: [sender_id], references: [user_id])
-  receiver User @relation("ReceivedMessages", fields: [receiver_id], references: [user_id])
+  receiver    User      @relation("ReceivedMessages", fields: [receiver_id], references: [user_id])
+  sender      User      @relation("SentMessages", fields: [sender_id], references: [user_id])
 
   @@index([receiver_id], map: "Message_receiver_id_fkey")
   @@index([sender_id], map: "Message_sender_id_fkey")

--- a/src/withdrawals/controllers/withdrawal.controller.ts
+++ b/src/withdrawals/controllers/withdrawal.controller.ts
@@ -13,7 +13,7 @@ export const WithdrawalController = {
     }
 
     try {
-      const response = await WithdrawalService.requestWithdrawal(user.user_id, req.body);
+      const response = await WithdrawalService.requestWithdrawal(user.user_id);
       return res.status(200).json(response);
     } catch (err: any) {
       const status = err.statusCode || 500;

--- a/src/withdrawals/dtos/withdrawal.dto.ts
+++ b/src/withdrawals/dtos/withdrawal.dto.ts
@@ -1,7 +1,3 @@
-export interface WithdrawalRequestDto {
-  amount: number;
-}
-
 export interface WithdrawalResponseDto {
   message: string;
   status: string;

--- a/src/withdrawals/services/withdrawal.service.ts
+++ b/src/withdrawals/services/withdrawal.service.ts
@@ -1,40 +1,31 @@
 import { WithdrawalRepository } from "../repositories/withdrawal.repository";
-import { WithdrawalRequestDto, WithdrawalResponseDto } from "../dtos/withdrawal.dto";
+import { WithdrawalResponseDto } from "../dtos/withdrawal.dto";
+
+const MIN_WITHDRAWAL = 10_000; // 10,000원
 
 export const WithdrawalService = {
-  async requestWithdrawal(userId: number, dto: WithdrawalRequestDto): Promise<WithdrawalResponseDto> {
-    const { amount } = dto;
-
-    // 1. 최소 출금 금액 확인
-    if (amount < 10000) {
-      throw {
-        statusCode: 400,
-        error: 'InvalidWithdrawalAmount',
-        message: '출금 가능 금액은 1,000원 이상이어야 합니다.',
-      };
-    }
-
-    // 2. 보유 정산금 계산
+  async requestWithdrawal(userId: number): Promise<WithdrawalResponseDto> {
+    // 가용 금액 계산
     const totalEarnings = await WithdrawalRepository.getUserTotalEarnings(userId);
     const totalWithdrawn = await WithdrawalRepository.getUserTotalWithdrawn(userId);
     const available = totalEarnings - totalWithdrawn;
 
-    // 3. 잔액 부족 여부 확인
-    if (amount > available) {
+    // 최소 금액 검증
+    if (available < MIN_WITHDRAWAL) {
       throw {
         statusCode: 400,
-        error: 'InsufficientBalance',
-        message: '출금 요청 금액이 잔액을 초과합니다.',
+        error: 'InvalidWithdrawalAmount',
+        message: '출금 가능 금액은 10,000원 이상이어야 합니다.',
       };
     }
 
-    // 4. 출금 요청 생성
-    const withdrawRequest = await WithdrawalRepository.createWithdrawalRequest(userId, amount);
+      // 전체 가용 금액으로 출금 요청 생성
+    const wr = await WithdrawalRepository.createWithdrawalRequest(userId, available);
 
     return {
       message: '출금이 완료되었습니다.',
       status: 'Succeed',
-      requested_at: withdrawRequest.created_at.toISOString(),
+      requested_at: wr.created_at.toISOString(),
       statusCode: 200,
     };
   },


### PR DESCRIPTION
## 📌 기능 설명
출금 요청 시 **사용자 가용 금액 전체를 자동 출금**하도록 로직을 수정했습니다.
또한 **최소 출금 가능 금액을 10,000원**으로 상향하여, 가용 금액이 10,000원 미만이면 출금이 불가합니다.

* 엔드포인트: `POST /api/settlements/withdrawals` (동일)
* 요청 바디: **없음** (기존 `amount`는 사용하지 않음)
* 가용 금액 계산:
  `Settlement(status='SUCCEED') 합계` − `WithdrawRequest(status IN ('PENDING','SUCCEED')) 합계`

## 📌 구현 내용
* **Service**

  * `MIN_WITHDRAWAL = 10_000` 적용
  * 가용 금액 < 10,000 → `400 InvalidWithdrawalAmount`
  * 가용 금액 ≥ 10,000 → **가용 금액 전액**으로 `WithdrawRequest` 생성 (`status: 'Succeed'` 사용)
* **Repository**

  * `getUserTotalEarnings(userId)` : `Settlement`의 `status='SUCCEED'` 합계 조회
  * `getUserTotalWithdrawn(userId)` : `WithdrawRequest`의 `status IN ('PENDING','SUCCEED')` 합계 조회
  * `createWithdrawalRequest(userId, amount)` : 계산된 전체 가용 금액으로 생성
* **Controller**

  * 요청 바디의 `amount` **무시**
  * 에러 메시지/코드 최신화(10,000원 기준)
* **DTO**

  * 요청 DTO(`amount`) **삭제**
  * 응답 DTO는 기존 포맷 유지
* **Route**

  * 변경 없음 (`POST /api/settlements/withdrawals`)
* **호환성 안내 (Breaking)**

  * 기존 클라이언트가 `amount`를 보내도 **무시**됩니다. 클라이언트에서 바디 없이 호출하도록 변경해 주세요.

### ✅ 성공 응답 예시

```json
{
  "message": "출금이 완료되었습니다.",
  "status": "Succeed",
  "requested_at": "2025-07-04T10:00:00.000Z",
  "statusCode": 200
}
```

### ❌ 에러 응답 예시

* **미인증**

```json
{
  "error": "Unauthorized",
  "message": "로그인이 필요합니다.",
  "statusCode": 401
}
```

* **최소 금액 미만 (가용 금액 < 10,000)**

```json
{
  "error": "InvalidWithdrawalAmount",
  "message": "출금 가능 금액은 10,000원 이상이어야 합니다.",
  "statusCode": 400
}
```

## 📌 구현 결과
<img width="1155" height="586" alt="image" src="https://github.com/user-attachments/assets/63a6b0af-d976-423b-8eec-d073547e8aa8" />
제가 현재 3000원밖에 없어서 저렇게 뜨는데 10000원 이상 DB에 넣어 보고 테스트 해 보겠습니다.

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->