### PR TITLE
Fix: 깃허브 워크플로우 수정

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -2,95 +2,104 @@ name: deploy-main
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Check prisma has changes
-        uses: dorny/paths-filter@v3
         id: paths-filter
+        uses: dorny/paths-filter@v3
         with:
           filters: |
             prisma: ["prisma/**"]
 
       - name: Configure SSH
+        env:
+          EC2_USER: ubuntu
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
         run: |
+          set -euo pipefail
           mkdir -p ~/.ssh
-          echo "$EC2_SSH_KEY" > ~/.ssh/id_rsa
+          printf "%s" "$EC2_SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           cat >>~/.ssh/config <<END
-          Host promptplace
+          Host prod
             HostName $EC2_HOST
             User $EC2_USER
             IdentityFile ~/.ssh/id_rsa
             StrictHostKeyChecking no
           END
-        env:
-          EC2_USER: ubuntu
-          EC2_HOST: ${{ secrets.EC2_HOST }}
-          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
 
-      - name: Copy Workspace
+      - name: Prepare target dir
         run: |
-          ssh promptplace 'sudo mkdir -p /opt/app'
-          ssh promptplace 'sudo chown ubuntu:ubuntu /opt/app'
-          scp -r ./[!.]* promptplace:/opt/app
+          ssh prod 'sudo mkdir -p /opt/app && sudo chown ubuntu:ubuntu /opt/app'
+
+      - name: Sync workspace (rsync --delete)
+        run: |
+          rsync -az --delete \
+            --exclude ".git" \
+            --exclude "node_modules" \
+            ./ prod:/opt/app/
 
       - name: Write .env on EC2
         run: |
-          ssh promptplace '
-            cat > /opt/app/.env <<EOF
+          ssh prod 'cat > /opt/app/.env <<EOF
           ${{ secrets.ENV_CONTENT }}
-          EOF
-          '
+          EOF'
 
-      - name: Install dependencies
+      - name: Install & Build on server
         run: |
-          ssh promptplace 'cd /opt/app && pnpm install'
+          ssh prod 'cd /opt/app && pnpm install --frozen-lockfile && pnpm build'
 
-      - name: Generate Prisma client
+      - name: Prisma generate
         run: |
-          ssh promptplace 'cd /opt/app && pnpm exec prisma generate'
+          ssh prod 'cd /opt/app && pnpm exec prisma generate'
 
-      - name: Apply Prisma migrations
+      - name: Prisma migrate (only when schema changed)
         if: steps.paths-filter.outputs.prisma == 'true'
         run: |
-          ssh promptplace 'cd /opt/app && pnpm exec prisma migrate deploy'
+          ssh prod 'cd /opt/app && pnpm exec prisma migrate deploy'
 
-      - name: Build TypeScript on server
+      - name: Install/Update systemd service
         run: |
-          ssh promptplace 'cd /opt/app && pnpm exec tsc && rm -rf dist&& pnpm build'
+          ssh prod 'cat > app.service << "UNIT"
+          [Unit]
+          Description=PromptPlace Backend
+          After=network.target
 
-      - name: Copy systemd service file
-        run: |
-          ssh promptplace '
-            echo "[Unit]
-            Description=PromptPlace Backend
-            After=network.target
+          [Service]
+          User=ubuntu
+          WorkingDirectory=/opt/app
+          EnvironmentFile=/opt/app/.env
+          Environment=NODE_ENV=production
+          Environment=PNPM_HOME=/home/ubuntu/.local/share/pnpm
+          Environment=PATH=/home/ubuntu/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin
+          ExecStart=/bin/bash -lc '"'"'pnpm start'"'"'
+          Restart=always
+          RestartSec=3
+          # Optional: 확보/로그
+          StandardOutput=journal
+          StandardError=journal
 
-            [Service]
-            User=ubuntu
-            WorkingDirectory=/opt/app
-            EnvironmentFile=/opt/app/.env
-            ExecStart=/usr/bin/pnpm start
-            Restart=always
-
-            [Install]
-            WantedBy=multi-user.target" | sudo tee /etc/systemd/system/app.service
+          [Install]
+          WantedBy=multi-user.target
+          UNIT
+          sudo mv app.service /etc/systemd/system/app.service
+          sudo systemctl daemon-reload
+          sudo systemctl enable app
+          sudo systemctl restart app
           '
 
-      - name: Enable systemd service
+      # PM2를 쓰고 있었다면 서비스 충돌 방지를 위해 종료(1회 실행)
+      - name: Stop PM2 app (one-time)
         run: |
-          ssh promptplace 'sudo systemctl daemon-reload'
-          ssh promptplace 'sudo systemctl enable app'
-
-      - name: Restart systemd service
-        run: |
-          ssh promptplace 'sudo systemctl restart app'
+          ssh prod 'pm2 delete promptplace || true'


### PR DESCRIPTION
## 📌 기능 설명
기존 배포 워크플로우에서 배포 경로와 실제 서비스 실행 경로가 일치하지 않아 최신 코드가 서비스에 반영되지 않는 문제가 있었습니다.
이번 수정에서는 실행 경로를 `/opt/app`으로 통일하고, systemd를 통해 앱을 재시작하도록 워크플로우를 개선했습니다.

## 📌 구현 내용
* 배포 대상 경로를 `/opt/app`으로 고정
* `rsync --delete` 사용하여 잔여 파일 제거 및 디렉토리 정합성 보장
* systemd 서비스 유닛 파일 내 `pnpm` PATH 환경 변수 명시
* Prisma 변경 시에만 `migrate deploy` 실행하도록 조건 유지
* PM2 사용 중단 및 충돌 방지를 위해 기존 PM2 앱 제거 스텝 추가
* 배포 후 `systemctl daemon-reload` 및 `systemctl restart app`으로 서비스 자동 재시작

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->