### PR TITLE
Feat: 계좌 관련 스키마 추가

### DIFF
--- a/prisma/migrations/20250815_add_bank/migration.sql
+++ b/prisma/migrations/20250815_add_bank/migration.sql
@@ -1,0 +1,50 @@
+-- CreateTable
+CREATE TABLE `Bank` (
+    `code` CHAR(3) NOT NULL,
+    `name` VARCHAR(50) NOT NULL,
+
+    PRIMARY KEY (`code`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `PreRegisteredAccount` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `bank_code` CHAR(3) NOT NULL,
+    `account_number` VARCHAR(30) NOT NULL,
+    `account_holder` VARCHAR(100) NOT NULL,
+    `owner_user_id` INTEGER NOT NULL,
+    `is_active` BOOLEAN NOT NULL DEFAULT true,
+
+    INDEX `PreRegisteredAccount_bank_code_idx`(`bank_code`),
+    INDEX `PreRegisteredAccount_account_number_idx`(`account_number`),
+    UNIQUE INDEX `uniq_user_prereg_account`(`owner_user_id`, `bank_code`, `account_number`, `account_holder`),
+    UNIQUE INDEX `uniq_prereg_id_owner`(`id`, `owner_user_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `UserBankAccount` (
+    `account_id` INTEGER NOT NULL AUTO_INCREMENT,
+    `user_id` INTEGER NOT NULL,
+    `preregistered_id` INTEGER NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `UserBankAccount_user_id_key`(`user_id`),
+    UNIQUE INDEX `UserBankAccount_preregistered_id_key`(`preregistered_id`),
+    UNIQUE INDEX `uniq_userbank_prereg_user`(`preregistered_id`, `user_id`),
+    PRIMARY KEY (`account_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `PreRegisteredAccount` ADD CONSTRAINT `PreRegisteredAccount_bank_code_fkey` FOREIGN KEY (`bank_code`) REFERENCES `Bank`(`code`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PreRegisteredAccount` ADD CONSTRAINT `PreRegisteredAccount_owner_user_id_fkey` FOREIGN KEY (`owner_user_id`) REFERENCES `User`(`user_id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserBankAccount` ADD CONSTRAINT `UserBankAccount_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `User`(`user_id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserBankAccount` ADD CONSTRAINT `UserBankAccount_preregistered_id_user_id_fkey` FOREIGN KEY (`preregistered_id`, `user_id`) REFERENCES `PreRegisteredAccount`(`id`, `owner_user_id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,35 +8,37 @@ datasource db {
 }
 
 model User {
-  user_id           Int                        @id @default(autoincrement())
-  name              String                     @db.VarChar(50)
-  nickname          String                     @db.VarChar(50)
-  email             String                     @unique @db.VarChar(255)
-  social_type       String                     @db.VarChar(50)
-  status            Boolean
-  inactive_date     DateTime?
-  created_at        DateTime                   @default(now())
-  updated_at        DateTime                   @updatedAt
-  role              Role                       @default(USER)
-  announcements     Announcement[]
-  receivedMessages  Message[]                  @relation("ReceivedMessages")
-  sentMessages      Message[]                  @relation("SentMessages")
-  sentNotifications Notification[]             @relation("ActorNotifications")
-  notifications     Notification[]             @relation("UserNotifications")
-  subscribers       NotificationSubscription[] @relation("NotificationTargetPrompter")
-  subscriptions     NotificationSubscription[] @relation("NotificationSubscriber")
-  prompts           Prompt[]
-  prompt_likes      PromptLike[]
-  prompt_reports    PromptReport[]             @relation("UserReport")
-  purchases         Purchase[]
-  refreshTokens     RefreshToken[]
-  reviews           Review[]
-  settlements       Settlement[]               @relation("UserSettlements")
-  tips              Tip[]
-  profileImage      UserImage?
-  intro             UserIntro?
-  sns_list          UserSNS[]
-  withdraw_requests WithdrawRequest[]
+  user_id              Int                        @id @default(autoincrement())
+  name                 String                     @db.VarChar(50)
+  nickname             String                     @db.VarChar(50)
+  email                String                     @unique @db.VarChar(255)
+  social_type          String                     @db.VarChar(50)
+  status               Boolean
+  inactive_date        DateTime?
+  created_at           DateTime                   @default(now())
+  updated_at           DateTime                   @updatedAt
+  role                 Role                       @default(USER)
+  announcements        Announcement[]
+  receivedMessages     Message[]                  @relation("ReceivedMessages")
+  sentMessages         Message[]                  @relation("SentMessages")
+  sentNotifications    Notification[]             @relation("ActorNotifications")
+  notifications        Notification[]             @relation("UserNotifications")
+  subscribers          NotificationSubscription[] @relation("NotificationTargetPrompter")
+  subscriptions        NotificationSubscription[] @relation("NotificationSubscriber")
+  prompts              Prompt[]
+  prompt_likes         PromptLike[]
+  prompt_reports       PromptReport[]             @relation("UserReport")
+  purchases            Purchase[]
+  refreshTokens        RefreshToken[]
+  reviews              Review[]
+  settlements          Settlement[]               @relation("UserSettlements")
+  tips                 Tip[]
+  profileImage         UserImage?
+  intro                UserIntro?
+  sns_list             UserSNS[]
+  withdraw_requests    WithdrawRequest[]
+  PreRegisteredAccount PreRegisteredAccount[]
+  UserBankAccount      UserBankAccount?
 }
 
 model UserIntro {
@@ -376,6 +378,46 @@ model Review {
 
   @@index([prompt_id], map: "Review_prompt_id_fkey")
   @@index([user_id], map: "Review_user_id_fkey")
+}
+
+model Bank {
+  code   String                 @id @db.Char(3)
+  name   String                 @db.VarChar(50)
+  prereg PreRegisteredAccount[]
+}
+
+model PreRegisteredAccount {
+  id             Int     @id @default(autoincrement())
+  bank_code      String  @db.Char(3)
+  account_number String  @db.VarChar(30)
+  account_holder String  @db.VarChar(100)
+  owner_user_id  Int // ← 계좌 소유자(필수)
+  is_active      Boolean @default(true)
+
+  bank        Bank             @relation(fields: [bank_code], references: [code], onDelete: Restrict)
+  owner       User             @relation(fields: [owner_user_id], references: [user_id], onDelete: Cascade)
+  userAccount UserBankAccount?
+
+  // 한 유저에게 같은 계좌가 중복 등록되지 않도록
+  @@unique([owner_user_id, bank_code, account_number, account_holder], map: "uniq_user_prereg_account")
+  // 복합 FK를 위한 유니크(참조 대상은 PK/UNIQUE 여야 함)
+  @@unique([id, owner_user_id], map: "uniq_prereg_id_owner")
+  @@index([bank_code])
+  @@index([account_number])
+}
+
+model UserBankAccount {
+  account_id       Int      @id @default(autoincrement())
+  user_id          Int      @unique // 유저당 1개
+  preregistered_id Int      @unique // 같은 계좌 재사용 금지(여러 유저 공유 허용 안함)
+  created_at       DateTime @default(now())
+  updated_at       DateTime @updatedAt
+
+  user          User                 @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+  // (preregistered_id, user_id) -> (id, owner_user_id) 로 복합 FK (본인만 등록 가능)
+  preregistered PreRegisteredAccount @relation(fields: [preregistered_id, user_id], references: [id, owner_user_id], onDelete: Restrict)
+
+  @@unique([preregistered_id, user_id], map: "uniq_userbank_prereg_user")
 }
 
 enum Status {


### PR DESCRIPTION
## 📌 기능 설명
사용자가 본인 명의의 계좌만 등록할 수 있도록 하기 위해 계좌 관련 테이블을 추가하고,
계좌 소유자 검증이 가능하도록 스키마를 설계했습니다.

## 📌 구현 내용
- `PreRegisteredAccount` 모델 추가
  - 은행 코드, 계좌번호, 예금주, 소유자(`owner_user_id`) 필드 정의
  - 소유자 기준 중복 방지 유니크 제약(`@@unique`)
  - `Bank` 및 `User`와의 관계 설정
  - `(id, owner_user_id)` 복합 유니크 키 추가 → 복합 FK 타깃

- `UserBankAccount` 모델 추가
  - 유저당 1개 계좌만 등록 가능(`user_id` @unique)
  - 같은 사전 등록 계좌 재사용 금지(`preregistered_id` @unique)
  - `(preregistered_id, user_id)` 복합 유니크 → 본인 소유 계좌만 FK 등록 가능
  - `User` 및 `PreRegisteredAccount`와의 관계 설정

- 본인 명의 계좌만 등록 가능하도록 `(preregistered_id, user_id) -> (id, owner_user_id)` 복합 FK 구성

> 이 스키마를 기반으로 계좌 등록 API 구현 시, DB 레벨에서 소유자 불일치 계좌 등록을 차단합니다.

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->