### PR TITLE
Feat: 계좌 정보 불러오기 API 구현

### DIFF
--- a/src/accounts/controllers/account.controller.ts
+++ b/src/accounts/controllers/account.controller.ts
@@ -29,3 +29,22 @@ export const registerAccount = async (req: Request, res: Response, next: NextFun
     next(err);
   }
 };
+
+export const getAccount = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.user?.user_id;
+
+    if (!userId) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        message: "로그인이 필요합니다.",
+        statusCode: 401,
+      });
+    }
+
+    const result = await AccountService.getAccountInfo(userId);
+    res.status(200).json(result);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/accounts/dtos/account.dto.ts
+++ b/src/accounts/dtos/account.dto.ts
@@ -11,3 +11,11 @@ export class RegisterAccountDto {
   @IsString()
   account_holder!: string;
 }
+
+export class GetAccountResponseDto {
+  account_id!: number;
+  bank_code!: string;
+  bank_name!: string;
+  account_number!: string;
+  account_holder!: string;
+}

--- a/src/accounts/repositories/account.repository.ts
+++ b/src/accounts/repositories/account.repository.ts
@@ -51,4 +51,17 @@ export const AccountRepository = {
       },
     });
   },
+
+  getUserBankAccount: async (userId: number) => {
+    return prisma.userBankAccount.findUnique({
+      where: { user_id: userId },
+      include: {
+        preregistered: {
+          include: {
+            bank: true, // bank.name 포함
+          },
+        },
+      },
+    });
+  },
 };

--- a/src/accounts/routes/account.route.ts
+++ b/src/accounts/routes/account.route.ts
@@ -1,9 +1,12 @@
 import { Router } from "express";
-import { registerAccount } from "../controllers/account.controller";
+import { registerAccount, getAccount } from "../controllers/account.controller";
 import { authenticateJwt } from "../../config/passport";
 
 const router = Router();
 
+// POST /api/members/me/accounts
 router.post("/accounts", authenticateJwt, registerAccount);
+// GET /api/members/me/accounts
+router.get("/accounts", authenticateJwt, getAccount);
 
 export default router;

--- a/src/accounts/services/account.service.ts
+++ b/src/accounts/services/account.service.ts
@@ -48,4 +48,27 @@ export const AccountService = {
       statusCode: 200,
     };
   },
+
+  getAccountInfo: async (userId: number) => {
+    const userAccount = await AccountRepository.getUserBankAccount(userId);
+
+    if (!userAccount) {
+      throw new AppError("등록된 계좌 정보가 없습니다.", 404, "NotFound");
+    }
+
+    const prereg = userAccount.preregistered;
+    const bank = prereg.bank;
+
+    return {
+      message: "계좌 정보를 불러왔습니다.",
+      data: {
+        account_id: userAccount.account_id,
+        bank_code: prereg.bank_code,
+        bank_name: bank.name,
+        account_number: prereg.account_number,
+        account_holder: prereg.account_holder,
+      },
+      statusCode: 200,
+    };
+  },
 };


### PR DESCRIPTION
## 📌 기능 설명
사용자가 본인의 계좌 정보를 조회할 수 있는 **GET `/api/members/me/accounts`** API를 구현했습니다.
인증된 사용자만 접근 가능하며, 등록된 계좌 정보를 반환합니다.

## 📌 구현 내용
* ✅ **계좌 조회 API 구현 (`GET /api/members/me/accounts`)**

  * JWT 인증된 사용자만 요청 가능 (`Authorization: Bearer {token}`)
  * 등록된 계좌 정보가 없을 경우 `404 NotFound` 에러 반환
* ✅ **DTO, Repository, Service, Controller, Route 구조로 분리**
* ✅ **`UserBankAccount` → `PreRegisteredAccount` → `Bank` 테이블 조인 조회**
* ✅ **응답 형식 명세에 맞춰 정리**

  ```json
  {
    "message": "계좌 정보를 불러왔습니다.",
    "data": {
      "account_id": 123,
      "bank_code": "090",
      "bank_name": "카카오뱅크",
      "account_number": "3333222111000",
      "account_holder": "홍길동"
    },
    "statusCode": 200
  }
  ```
* ✅ **예외 처리**

  * 미인증 요청 시: `401 Unauthorized`
  * 등록된 계좌 없을 시: `404 NotFound`
  * 서버 오류 발생 시: `500 Internal Server Error`
  * 
## 📌 구현 결과
<img width="1158" height="760" alt="image" src="https://github.com/user-attachments/assets/b226d216-5796-469f-aa11-4f1e1bbd809d" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->