### PR TITLE
feat: 회원 탈퇴 로직 추가

### DIFF
--- a/src/config/passport.ts
+++ b/src/config/passport.ts
@@ -30,9 +30,12 @@ passport.use(
           where: { user_id: jwtPayload.id },
         });
 
-        if (!user) return done(null, false);
+        // 여기만 추가하면 됩니다!
+        if (!user || !user.status) {
+          return done(null, false);
+        }
 
-        req.user = user; // 커스텀으로 req.user 확장 시 타입 정의 필요
+        req.user = user;
         return done(null, user);
       } catch (err) {
         return done(err as Error, false);

--- a/src/members/routes/member.route.ts
+++ b/src/members/routes/member.route.ts
@@ -187,10 +187,7 @@ router.get(
  *         description: 서버 오류
  */
 // 특정 회원 정보 조회 API - 인증 불필요
-router.get(
-  "/:memberId",
-  memberController.getMemberById.bind(memberController)
-);
+router.get("/:memberId", memberController.getMemberById.bind(memberController));
 
 /**
  * @swagger


### PR DESCRIPTION
## 📌 기능 설명
회원 탈퇴 후에도 JWT 토큰이 유효하여 다른 서비스에 접근할 수 있는 보안 취약점을 해결했습니다. Passport JWT Strategy에서 사용자 상태를 확인하여 탈퇴한 회원(`status: false`)의 모든 API 접근을 자동으로 차단하도록 개선했습니다.

## 📌 구현 내용

### **1. Passport JWT Strategy 보안 강화**
- **기존**: 사용자 존재 여부만 확인 (`!user`)
- **개선**: 사용자 존재 여부 + 활성 상태 확인 (`!user || !user.status`)
- **위치**: `src/config/passport.ts`의 JWT Strategy

### **2. 자동 보안 적용**
- **모든 인증이 필요한 API**에 자동 적용
- **별도 미들웨어 추가 불필요**
- **기존 코드 구조 유지**

### **3. 보안 로직**
```typescript
// 기존 코드
if (!user) return done(null, false);

// 개선된 코드
if (!user || !user.status) {
  return done(null, false);
}
```

## 📌 구현 결과

### **보안 강화 효과**
- ✅ **탈퇴한 회원 자동 차단**: `status: false`인 사용자 즉시 차단
- ✅ **전체 API 보안**: 인증이 필요한 모든 엔드포인트에 자동 적용
- ✅ **즉시 적용**: 회원 탈퇴 직후 다음 API 호출부터 차단

### **API 응답 예시**
```json
// 탈퇴한 회원이 API 호출 시
{
  "error": "Unauthorized",
  "message": "Unauthorized",
  "statusCode": 401
}
```

### **보안 적용 범위**
- **회원 관련**: 프로필 조회, 수정, 팔로우 등
- **프롬프트 관련**: 작성, 수정, 삭제 등
- **결제 관련**: 구매, 정산 등
- **기타 모든 인증 필요 API**

### **사용자 경험**
- **탈퇴 전**: 정상적으로 모든 서비스 이용 가능
- **탈퇴 직후**: 모든 API 접근 차단, 자동 로그아웃 효과
- **재가입 시**: 새로운 계정으로 정상 서비스 이용 가능

## 📌 논의하고 싶은 점
