### PR TITLE
fix: 회원 탈퇴 로직 수정

### DIFF
--- a/src/config/social/google.ts
+++ b/src/config/social/google.ts
@@ -27,11 +27,18 @@ export function configureGoogleStrategy() {
           });
 
           if (user) {
-            // 사용자가 존재하면 정보를 덮어쓰지 않음 (사용자가 직접 수정한 정보 보존)
-            // 소셜 로그인은 단순히 인증만 처리
+            if (!user.status) {
+              user = await prisma.user.update({
+                where: { email },
+                data: {
+                  status: true,
+                  inactive_date: null,
+                  updated_at: new Date(),
+                },
+              });
+            }
             return done(null, user);
           } else {
-            // 사용자가 없으면 새로 생성
             user = await prisma.user.create({
               data: {
                 email,

--- a/src/config/social/naver.ts
+++ b/src/config/social/naver.ts
@@ -27,11 +27,19 @@ export function configureNaverStrategy() {
           });
 
           if (user) {
-            // 사용자가 존재하면 정보를 덮어쓰지 않음 (사용자가 직접 수정한 정보 보존)
-            // 소셜 로그인은 단순히 인증만 처리
+            if (!user.status) {
+              user = await prisma.user.update({
+                where: { email },
+                data: {
+                  status: true,
+                  inactive_date: null,
+                  updated_at: new Date(),
+                },
+              });
+            }
+
             return done(null, user);
           } else {
-            // 사용자가 없으면 새로 생성
             user = await prisma.user.create({
               data: {
                 email,


### PR DESCRIPTION
## 📌 기능 설명
회원 탈퇴 후 동일한 이메일로 소셜 로그인을 시도할 때 발생하는 문제를 해결했습니다. 탈퇴한 사용자(`status: false`)가 재로그인 시도 시 자동으로 계정을 재활성화하여, 새로운 계정을 생성하지 않고도 안전하게 서비스를 이용할 수 있도록 개선했습니다.

## 📌 구현 내용

### **1. 소셜 로그인 전략 개선**
- **네이버**: `src/config/social/naver.ts` 수정
- **구글**: `src/config/social/google.ts` 수정  
- **카카오**: `src/config/social/kakao.ts` 수정

### **2. 탈퇴한 사용자 재활성화 로직**
```typescript
if (user) {
  if (!user.status) {
    // 탈퇴한 사용자인 경우 재활성화
    user = await prisma.user.update({
      where: { email },
      data: {
        status: true,
        inactive_date: null,
        updated_at: new Date(),
      },
    });
  }
  return done(null, user);
}
```

### **3. 데이터 무결성 보장**
- **이메일 unique 제약조건** 유지
- **기존 사용자 데이터** 보존
- **새로운 계정 생성** 방지

### **4. 보안 강화**
- **Passport JWT Strategy**에서 `!user.status` 체크
- **탈퇴한 사용자** 자동 차단
- **재활성화 후** 정상 서비스 이용 가능

## 📌 구현 결과

### **사용자 시나리오**
```
1. 사용자 A가 회원 탈퇴
   ↓
2. status: false, inactive_date 설정
   ↓
3. 동일한 이메일로 소셜 로그인 시도
   ↓
4. 자동으로 계정 재활성화
   ↓
5. 정상적으로 서비스 이용 가능
```

### **API 응답 예시**
```json
// 재활성화 후 로그인 성공
{
  "message": "네이버 로그인이 완료되었습니다.",
  "data": {
    "access_token": "eyJhbGciOiJIUzI1NiIs...",
    "refresh_token": "eyJhbGciOiJIUzI1NiIs...",
    "user": {
      "user_id": 5,
      "name": "송강규",
      "nickname": "송강규",
      "email": "ggsong0328@naver.com",
      "social_type": "NAVER",
      "status": "ACTIVE",
      "role": "USER"
    }
  },
  "statusCode": 200
}
```

### **데이터베이스 상태 변화**
```sql
-- 탈퇴 전
UPDATE User SET status = false, inactive_date = NOW() WHERE user_id = 5;

-- 재활성화 후
UPDATE User SET status = true, inactive_date = NULL, updated_at = NOW() WHERE user_id = 5;
```

### **주요 개선사항**
- ✅ **자동 재활성화**: 탈퇴한 사용자 자동 복구
- ✅ **데이터 보존**: 기존 사용자 정보 완전 보존
- ✅ **보안 강화**: 탈퇴한 계정 접근 차단
- ✅ **사용자 경험**: 재가입 절차 불필요
- ✅ **데이터 무결성**: 이메일 중복 방지

## 📌 논의하고 싶은 점
