### PR TITLE
Fix: 계좌 수정 시 기존 계좌 수정 대신 연결 교체 방식으로 변경

### DIFF
--- a/src/accounts/repositories/account.repository.ts
+++ b/src/accounts/repositories/account.repository.ts
@@ -65,16 +65,12 @@ export const AccountRepository = {
     });
   },
 
-   updatePreRegisteredAccount: async (preregId: number, data: {
-    bank_code: string;
-    account_number: string;
-    account_holder: string;
-  }) => {
-    return prisma.preRegisteredAccount.update({
-      where: { id: preregId },
-      data,
-    });
-  },
+   updateUserBankAccountPreregId: async (userId: number, preregistered_id: number) => {
+  return prisma.userBankAccount.update({
+    where: { user_id: userId },
+    data: { preregistered_id },
+  });
+},
 
   // 다른 유저가 등록한 동일 계좌가 있는지 검사
 findDuplicatePreRegisteredAccount: async ({


### PR DESCRIPTION
## 📌 기능 설명
유저가 이미 보유한 동일 계좌가 있을 경우 preRegisteredAccount 수정이 아닌,
해당 계좌를 UserBankAccount에 재연결하도록 로직 변경
UNIQUE 제약 조건 위반 오류 해결

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->