### PR TITLE
Fix/#253

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -223,8 +223,6 @@ model Prompt {
   downloads      Int
   views          Int
   likes          Int
-  review_counts  Int
-  rating_avg     Float
   created_at     DateTime       @default(now())
   updated_at     DateTime       @updatedAt
   inactive_date  DateTime?

--- a/src/prompts/controllers/prompt.controller.ts
+++ b/src/prompts/controllers/prompt.controller.ts
@@ -20,10 +20,11 @@ export const searchPrompts = async (req: Request, res: Response) => {
     } = req.body;
 
     // tag가 문자열인 경우 배열로 변환
+    const modelArray = typeof model === "string" ? [model] : (model as string[]) || [];
     const tagArray = typeof tag === "string" ? [tag] : (tag as string[]) || [];
 
     const dto: SearchPromptDto = {
-      model: typeof model === "string" ? model : "",
+      model: modelArray,
       tag: tagArray,
       keyword,
       page: Number(page),
@@ -34,7 +35,7 @@ export const searchPrompts = async (req: Request, res: Response) => {
 
     const results = await promptService.searchPrompts(dto);
 
-    if (!results || results.length === 0) {
+    if (!results) {
       return res.status(404).json({ message: "검색 결과가 없습니다." });
     }
 

--- a/src/prompts/dtos/search-prompt.dto.ts
+++ b/src/prompts/dtos/search-prompt.dto.ts
@@ -1,5 +1,5 @@
 export interface SearchPromptDto {
-  model: string | null;
+  model: string[] | null;
   tag: string[] | null;
   keyword: string | null;
   page: number;


### PR DESCRIPTION
## 📌 기능 설명
1. 프롬프트 요청 시 리뷰 개수 및 별점 평균 정보 포함
2. 모델 중복 필터 가능
3. 프롬프트 검색 시 닉네임이나 작성한 프롬프트가 연관된 유저 함께 전달
4. 프롬프트 검색 시 정렬 방법 추가

## 📌 구현 내용
1. fetchReviewStatsByPromptIds, attachReviewStats 함수를 작성하여 프롬프트의 리뷰 개수 및 별점 평균 정보를 직접 계산하여 추가.
2. model의 list화를 사용하여 모델 태그가 중복이 가능하도록 변경
3. 프롬프트 검색 API 요청 시 related_users로 연관된 유저들의 정보를 추가로 전달
4. 기존의 최신 순 정렬에 추가로 인기/ 다운로드/ 뷰/ 별점 순의 정렬도 추가로 작성


## 📌 구현 결과

<img width="413" height="126" alt="image" src="https://github.com/user-attachments/assets/3b2ae81a-9b41-4fe2-81dd-d4a86456f70b" />

<img width="800" height="986" alt="image" src="https://github.com/user-attachments/assets/b1e71d20-2ccd-4fa8-8cf9-bda40751f087" />

<img width="1294" height="994" alt="image" src="https://github.com/user-attachments/assets/2dbca72a-ba83-405f-82f5-d2d056f86d4d" />

<img width="567" height="153" alt="image" src="https://github.com/user-attachments/assets/5c90254c-0da9-4ccf-b866-caed6b22b5a5" />


## 📌 논의하고 싶은 점