### PR TITLE
fix: 최초 로그인 시 nickname 이름과 동일화

### DIFF
--- a/src/config/social/naver.ts
+++ b/src/config/social/naver.ts
@@ -44,7 +44,7 @@ export function configureNaverStrategy() {
               data: {
                 email,
                 name: profile.name || "Unknown",
-                nickname: profile.nickname || profile.name || "Unknown",
+                nickname: profile.name || "Unknown",
                 social_type: "NAVER",
                 status: true,
                 role: "USER",


### PR DESCRIPTION
## 📌 기능 설명
최초 로그인 시 nickname 이름과 동일화했습니다

## 📌 구현 내용
```
user = await prisma.user.create({
              data: {
                email,
                name: profile.name || "Unknown",
                nickname: profile.name || "Unknown", <- 이름과 동일
                social_type: "NAVER",
                status: true,
                role: "USER",
              },
            });
```

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->