### PR TITLE
fix: 401 Unauthorized 전역 에러로 등록

### DIFF
--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -9,6 +9,21 @@ export const errorHandler = (
 ): void => {
   if (res.headersSent) return next(err);
 
+  // 401 에러 통일 처리
+  if (
+    err.statusCode === 401 ||
+    err.message === "Unauthorized" ||
+    err.name === "JsonWebTokenError" ||
+    err.name === "TokenExpiredError"
+  ) {
+    res.status(401).json({
+      error: "Unauthorized",
+      message: "로그인이 필요합니다.",
+      statusCode: 401,
+    });
+    return;
+  }
+
   if (err instanceof AppError) {
     res.fail({
       statusCode: err.statusCode,


### PR DESCRIPTION
## 📌 기능 설명
401 Unauthorized 전역 에러로 등록

## 📌 구현 내용
```
 // 401 에러 통일 처리
  if (
    err.statusCode === 401 ||
    err.message === "Unauthorized" ||
    err.name === "JsonWebTokenError" ||
    err.name === "TokenExpiredError"
  ) {
    res.status(401).json({
      error: "Unauthorized",
      message: "로그인이 필요합니다.",
      statusCode: 401,
    });
    return;
  }
```

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->