### PR TITLE
feat: 회원 탈퇴 후 재가입 로직

### DIFF
--- a/src/config/passport.ts
+++ b/src/config/passport.ts
@@ -11,6 +11,7 @@ import { Request } from "express";
 import { configureGoogleStrategy } from "./social/google";
 import { configureNaverStrategy } from "./social/naver";
 import { configureKakaoStrategy } from "./social/kakao";
+import { isActive } from "../utils/status";
 import prisma from "./prisma";
 
 // JWT Strategy 설정
@@ -30,7 +31,7 @@ passport.use(
           where: { user_id: jwtPayload.id },
         });
 
-        if (!user || !user.status) {
+        if (!user || !isActive(user.status)) {
           // 커스텀 에러 객체로 반환
           const error = new Error("Unauthorized");
           (error as any).statusCode = 401;

--- a/src/config/social/google.ts
+++ b/src/config/social/google.ts
@@ -27,16 +27,6 @@ export function configureGoogleStrategy() {
           });
 
           if (user) {
-            if (!user.status) {
-              user = await prisma.user.update({
-                where: { email },
-                data: {
-                  status: true,
-                  inactive_date: null,
-                  updated_at: new Date(),
-                },
-              });
-            }
             return done(null, user);
           } else {
             user = await prisma.user.create({
@@ -49,9 +39,8 @@ export function configureGoogleStrategy() {
                 role: "USER",
               },
             });
+            return done(null, user);
           }
-
-          return done(null, user);
         } catch (error) {
           return done(error, false);
         }

--- a/src/config/social/naver.ts
+++ b/src/config/social/naver.ts
@@ -27,17 +27,6 @@ export function configureNaverStrategy() {
           });
 
           if (user) {
-            if (!user.status) {
-              user = await prisma.user.update({
-                where: { email },
-                data: {
-                  status: true,
-                  inactive_date: null,
-                  updated_at: new Date(),
-                },
-              });
-            }
-
             return done(null, user);
           } else {
             user = await prisma.user.create({
@@ -50,9 +39,8 @@ export function configureNaverStrategy() {
                 role: "USER",
               },
             });
+            return done(null, user);
           }
-
-          return done(null, user);
         } catch (error) {
           return done(error, false);
         }

--- a/src/members/repositories/member.repository.ts
+++ b/src/members/repositories/member.repository.ts
@@ -144,12 +144,12 @@ export class MemberRepository {
   }
 
   async deactivateUser(userId: number) {
-    return prisma.user.update({
+    await prisma.$executeRawUnsafe(
+      "UPDATE `User` SET status = 0, inactive_date = NOW() WHERE user_id = ?",
+      userId
+    );
+    return prisma.user.findUnique({
       where: { user_id: userId },
-      data: {
-        status: false,
-        inactive_date: new Date(),
-      },
     });
   }
 

--- a/src/utils/status.ts
+++ b/src/utils/status.ts
@@ -1,0 +1,5 @@
+export const isActive = (status: unknown): boolean =>
+  status === true || status === 1 || status === "1";
+
+export const toTinyint = (flag: unknown): 0 | 1 =>
+  flag === true || flag === 1 || flag === "1" ? 1 : 0;


### PR DESCRIPTION
### 📌 기능 설명
- 회원 탈퇴 후 동일 계정(이메일)으로 30일간 재로그인이 불가하도록 쿨다운을 적용했습니다.
- 30일 경과 후 최초 소셜 로그인 시에만 자동 재활성화되며, 그 외에는 403으로 차단됩니다.

### 📌 구현 내용
- **재활성화 쿨다운(30일) 적용**
  - `inactive_date` 기준 30일이 지나지 않으면 로그인 시 `403 Forbidden` 반환.
  - 30일 경과 시 로그인 순간에만 `status=1`, `inactive_date=NULL`로 재활성화.

- **status 타입 불일치(tinyint vs boolean) 대응**
  - `src/utils/status.ts`에 `isActive`/`toTinyint` 유틸 추가로 상태 판별 표준화.
  - 상태 토글(비활성화/재활성화)은 숫자(0/1)로 DB에 직접 반영.

- **로그인 경로별 일관 처리**
  - 소셜 전략(`google`, `naver`, `kakao`): 기존 자동 재활성화 로직 제거. 사용자 조회만 수행.
  - 콜백 컨트롤러(`AuthController`): `isActive` 체크 → 30일 미경과 시 403, 경과 시 DB 재활성화 후 토큰 발급.
  - 토큰 교환 플로우(`exchangeGoogleToken`, `exchangeKakaoToken`, `exchangeNaverToken`): 동일 로직 적용.

- **JWT 인증 가드 보강**
  - `passport`에서 `user.status`를 `isActive`로 판별해 tinyint/boolean 혼용 환경에서도 정확히 동작.

- **DB 반영 방식**
  - 재활성화/비활성화 시 `prisma.$executeRawUnsafe`를 통해 `User` 테이블에 `status=0|1`로 직접 업데이트.
  - 테이블명과 컬럼 케이스를 정확히 지정하여 환경 의존성 최소화.

- **변경 파일(주요)**
  - `src/utils/status.ts`
  - `src/config/passport.ts`
  - `src/config/social/google.ts`, `src/config/social/naver.ts`, `src/config/social/kakao.ts`
  - `src/auth/controllers/auth.controller.ts`
  - `src/auth/services/auth.service.ts`
  - `src/members/services/member.service.ts`
  - `src/members/repositories/member.repository.ts` (탈퇴 시 `status=0`, `inactive_date=NOW()`로 업데이트)

### 📌 구현 결과
- 탈퇴 직후 동일 계정 재로그인 시: 403 응답
  - 에러 형식: 기존 전역 에러 포맷 준수(Unauthorized와 구분해 Forbidden으로 응답)
- 30일 경과 후 로그인: 자동 재활성화(상태 1 전환 및 `inactive_date` 초기화) + 정상 토큰 발급
- JWT 인증 미들웨어에서 tinyint/boolean 혼용 환경에서도 정확한 활성/비활성 판별

### 📌 논의하고 싶은 점