### PR TITLE
Fix/#281

### DIFF
--- a/src/inquiries/services/inquiry.service.ts
+++ b/src/inquiries/services/inquiry.service.ts
@@ -25,7 +25,7 @@ export class InquiryService {
       senderId,
       createInquiryDto
     );
- 
+
     // 새 문의 알림 이벤트 발생
     eventBus.emit("inquiry.created", receiver.user_id, senderId);
 
@@ -140,7 +140,11 @@ export class InquiryService {
     return inquiries.map((inquiry) => {
       // sender가 null일 수 있으므로 안전하게 처리
       if (!inquiry.sender) {
-        throw new AppError("발신자 정보를 찾을 수 없습니다.", 500, "InternalServerError");
+        throw new AppError(
+          "발신자 정보를 찾을 수 없습니다.",
+          500,
+          "InternalServerError"
+        );
       }
 
       return {
@@ -163,8 +167,8 @@ export class InquiryService {
       throw new AppError("해당 문의를 찾을 수 없습니다.", 404, "NotFound");
     }
 
-    // 2. 삭제 권한 확인 (문의 작성자인지)
-    if (inquiry.sender_id !== userId) {
+    // 2. 삭제 권한 확인 (문의 수신자인지)
+    if (inquiry.receiver_id !== userId) {
       throw new AppError("문의를 삭제할 권한이 없습니다.", 403, "Forbidden");
     }
 

--- a/src/members/routes/member.route.ts
+++ b/src/members/routes/member.route.ts
@@ -19,8 +19,6 @@ const memberController = new MemberController();
  *   get:
  *     summary: 회원의 팔로워 목록 조회
  *     tags: [Member]
- *     security:
- *       - jwt: []
  *     parameters:
  *       - in: path
  *         name: memberId
@@ -61,7 +59,6 @@ const memberController = new MemberController();
  */
 router.get(
   "/followers/:memberId",
-  authenticateJwt,
   memberController.getFollowers.bind(memberController)
 );
 


### PR DESCRIPTION
## 📌 기능 설명
문의 삭제 권한과 팔로워 목록 조회 접근 권한을 변경하는 기능입니다.

## 📌 구현 내용

### 1. 문의 삭제 권한 변경
- **기존**: 문의를 보낸 사람(sender)만 삭제 가능
- **변경**: 문의를 받은 사람(receiver)만 삭제 가능
- `src/inquiries/services/inquiry.service.ts`의 `deleteInquiry` 메서드에서 권한 검사 로직 수정

### 2. 팔로워 목록 조회 접근 권한 변경
- **기존**: JWT 토큰 인증이 필요한 인증된 사용자만 조회 가능
- **변경**: 토큰 없이도 누구나 조회 가능 (공개 API)
- `src/members/routes/member.route.ts`에서 `authenticateJwt` 미들웨어 제거
- Swagger 문서에서 `security` 필드 제거

## 📌 구현 결과

### 문의 삭제 권한 변경
```typescript
// 변경 전
if (inquiry.sender_id !== userId) {
  throw new AppError("문의를 삭제할 권한이 없습니다.", 403, "Forbidden");
}

// 변경 후
if (inquiry.receiver_id !== userId) {
  throw new AppError("문의를 삭제할 권한이 없습니다.", 403, "Forbidden");
}
```

### 팔로워 목록 조회 접근 권한 변경
```typescript
// 변경 전
router.get(
  "/followers/:memberId",
  authenticateJwt,  // JWT 인증 필요
  memberController.getFollowers.bind(memberController)
);

// 변경 후
router.get(
  "/followers/:memberId",
  memberController.getFollowers.bind(memberController)  // 인증 불필요
);
```

## 📌 논의하고 싶은 점
