### PR TITLE
[FIX] :caddyfile 서버 api 도메인 수정(#290)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -6,7 +6,7 @@
 }
 
 # api 도메인
-api.promptplace.kr {
+promptplace.kro.kr {
 	encode zstd gzip
 
 	# 보안 헤더


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
Caddyfile에서 백엔드 API 도메인을 `api.promptplace.kr`에서 `promptplace.kro.kr`로 수정했습니다.  
프론트엔드에서 호출하는 실제 도메인과 일치하도록 설정을 변경했습니다.

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
- Caddyfile의 사이트 블록 도메인 변경:  
  - 기존: `api.promptplace.kr`  
  - 변경: `promptplace.kro.kr`
- reverse proxy 대상(`app:3000`)은 동일하게 유지
- 보안 헤더 및 헬스체크 설정은 기존과 동일하게 유지

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
- `https://promptplace.kro.kr`에서 API 요청 시 더 이상 308 리다이렉트 발생하지 않음
- 브라우저 CORS 에러 해소 및 정상 응답 확인  
- 도커 로그 및 `curl` 테스트로 헬스체크/프록시 동작 검증 완료

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 --> 
- 로컬 개발 환경에서는 `localhost:3000`, `localhost:5173` CORS 허용 여부를 분리(`NODE_ENV` 기준)하는 것이 좋을지 의견 필요
