### PR TITLE
[FIX]: 308 리다이렉트 에러 최종 해결(#290)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,34 +1,46 @@
 {
-	# 프록시 앞단(도커 브리지 등)에서 온 X-Forwarded-* 신뢰
-	servers {
-		trusted_proxies static 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
-	}
+        # ALB 같은 프록시에서 온 X-Forwarded-* 헤더 신뢰
+        servers {
+                trusted_proxies static 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
+        }
+        # ALB가 HTTPS 처리하므로 Caddy는 HTTP만
+        auto_https off
 }
 
-# api 도메인
-https://promptplace.kro.kr {
-	encode zstd gzip
+http://promptplace.kro.kr {
+        encode zstd gzip
 
-	# 보안 헤더
-	header {
-		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-		X-Content-Type-Options "nosniff"
-		Referrer-Policy "strict-origin-when-cross-origin"
-	}
-	
-	# /api/* 요청만 프록시
-	handle_path /api/* {
-		reverse_proxy app:3000 {
-			health_uri     /health
-			health_interval 30s
-			health_timeout  3s
-			fail_duration   10s
-		}
-	}
-	
-	# 액세스 로그
-	log {
-		output stdout
-		format console
-	}
+        # 보안 헤더 (HSTS는 HTTPS 응답에서만 의미 있으므로 여기서는 생략 가능)
+        header {
+                X-Content-Type-Options "nosniff"
+                Referrer-Policy "strict-origin-when-cross-origin"
+        }
+
+        # /api/* 요청만 app:3000으로 프록시
+        handle /api/* {
+                reverse_proxy app:3000 {
+                        # 백엔드 상태 체크용 (Caddy→app)
+                        health_uri      /health
+                        health_interval 30s
+                        health_timeout  3s
+                        fail_duration   10s
+
+                        # ALB에서 받은 원래 요청 스킴/호스트/IP 전달
+                        header_up X-Forwarded-Proto {scheme}
+                        header_up X-Forwarded-Host  {host}
+                        header_up X-Real-IP         {remote_host}
+                }
+        }
+
+        # (선택) ALB 헬스체크 편의 엔드포인트
+        @health path /health
+        handle @health {
+                respond "ok" 200
+        }
+
+        # 로그
+        log {
+                output stdout
+                format console
+        }
 }


### PR DESCRIPTION
## 📌 기능 설명
308 리다이렉트 에러가 발생하던 문제를 최종적으로 해결했습니다.  
(ALB → Caddy → Express 사이에서 프로토콜 및 프록시 설정 불일치로 인한 리다이렉트 무한 루프/에러 현상 수정)

---

## 📌 구현 내용
- Caddy 설정 수정
  - `handle_path` → `handle` 로 변경하여 `/api` prefix 제거 문제 해결
  - `header_up X-Forwarded-Proto {scheme}` 추가하여 Express에서 HTTPS 인식 가능하도록 설정
- ALB 상태 검사 경로를 `/health` 로 명확히 맞춤
- 불필요한 자동 HTTPS 비활성화(`auto_https off`)로 ALB TLS 종료와 충돌 방지
- Express 라우트 `/health` 와 ALB 헬스체크 매칭 완료

---

## 📌 구현 결과
- `/api/members` 등 API 요청 시 더 이상 308 리다이렉트 에러 발생하지 않음
- 헬스체크 정상 통과 (ALB 대상 상태 "정상"으로 표시됨)
- 브라우저 및 curl 테스트 결과 정상적으로 200 응답 반환 확인

---

## 📌 논의하고 싶은 점
