### PR TITLE
fix: has_unread_messages 필드 추가

### DIFF
--- a/src/members/repositories/member.repository.ts
+++ b/src/members/repositories/member.repository.ts
@@ -197,6 +197,15 @@ export class MemberRepository {
       include: {
         intro: true,
         profileImage: true, // 프로필 이미지 포함
+        _count: {
+          select: {
+            receivedMessages: {
+              where: {
+                is_read: false,
+              },
+            },
+          },
+        },
       },
     });
   }

--- a/src/members/services/member.service.ts
+++ b/src/members/services/member.service.ts
@@ -132,6 +132,7 @@ export class MemberService {
       nickname: member.nickname,
       intros: member.intro?.description || null,
       profile_image: member.profileImage?.url || null, // 프로필 이미지 추가
+      has_unread_messages: (member._count?.receivedMessages ?? 0) > 0,
       created_at: member.created_at,
       updated_at: member.updated_at,
       status: member.status ? 1 : 0,


### PR DESCRIPTION
📌 기능 설명
회원 프로필 조회 API 응답에 해당 회원이 읽지 않은 메시지가 있는지 여부를 나타내는 has_unread_messages 필드를 추가했습니다. 이를 통해 클라이언트에서 안 읽은 메시지가 있다는 표시를 더 쉽게 구현할 수 있습니다.

📌 구현 내용
MemberRepository 수정 (src/members/repositories/member.repository.ts)
findUserWithIntroById 메서드에서 Prisma의 _count 기능을 활용하여 is_read가 false인 메시지의 개수를 함께 조회하도록 쿼리를 수정했습니다.
이 방식은 별도의 추가 쿼리 없이 한 번의 DB 요청으로 회원 정보와 안 읽은 메시지 수를 효율적으로 가져옵니다.
MemberService 수정 (src/members/services/member.service.ts)
getMemberById 메서드에서 Repository로부터 받은 안 읽은 메시지 개수(_count.receivedMessages)를 boolean 값으로 변환하여 has_unread_messages 필드를 생성하고 최종 응답 객체에 포함시켰습니다.

📌 구현 결과
API 응답 결과에 has_unread_messages 필드가 추가되었습니다.
