### PR TITLE
fix: github actions 오류 해결

### DIFF
--- a/src/notifications/repositories/notification.repository.ts
+++ b/src/notifications/repositories/notification.repository.ts
@@ -133,7 +133,7 @@ export const getLastNotificationCheckTime = async (
       user_id: userId
     }
   });
-  return user?.last_notification_check_time || null; 
+  return user?.lastNotificationCheckTime || null; 
 };
 
 
@@ -176,7 +176,7 @@ export const createNotificationCheckTime = async (
   await prisma.userNotificationSetting.create({
     data: {
       user_id: userId,
-      last_notification_check_time: new Date()
+      lastNotificationCheckTime: new Date()
     }
   });
 };
@@ -189,7 +189,7 @@ export const updateNotificationCheckTime = async (
       user_id: userId
     },
     data: {
-      last_notification_check_time: new Date()
+      lastNotificationCheckTime: new Date()
     }
   });
 };

--- a/src/prompts/controllers/prompt.controller.ts
+++ b/src/prompts/controllers/prompt.controller.ts
@@ -174,11 +174,10 @@ export const createPrompt = async (req: Request, res: Response) => {
     const invalidFields: string[] = [];
 
     // 문자열 필수 필드: 빈 문자열 불가
-    const stringRequired = ['title', 'prompt', 'description'];
-    for (const key of stringRequired) {
-      if (typeof dto[key] !== "string" || !dto[key].trim())
-        invalidFields.push(key);
-    }
+    if (typeof dto.title !== 'string' || !dto.title.trim()) invalidFields.push('title');
+    if (typeof dto.prompt !== 'string' || !dto.prompt.trim()) invalidFields.push('prompt');
+    if (typeof dto.description !== 'string' || !dto.description.trim()) invalidFields.push('description');
+
 
     // model_version: 선택적, 50자 제한
     if (dto.model_version && (typeof dto.model_version !== 'string' || dto.model_version.length > 50)) {

--- a/src/prompts/services/prompt.service.ts
+++ b/src/prompts/services/prompt.service.ts
@@ -121,7 +121,7 @@ export const getGroupedCategories = async () => {
   const result: { [key: string]: string[] } = {};
 
   for (const mainCategory of data) {
-    result[mainCategory.name] = mainCategory.categories.map(c => c.name);
+    result[mainCategory.name] = mainCategory.categories.map((c: { name: string }) => c.name);
   }
 
   return result;
@@ -132,7 +132,7 @@ export const getGroupedModels = async () => {
   const result: { [key: string]: string[] } = {};
 
   for (const modelCategory of data) {
-    result[modelCategory.name] = modelCategory.models.map(m => m.name);
+    result[modelCategory.name] = modelCategory.models.map((m: { name: string }) => m.name);
   }
 
   return result;


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->

## 📌 구현 내용
모든 타입스크립트 오류를 수정했습니다.
수정 내역:
Prisma Client 재생성: prisma generate를 실행하여 데이터베이스 스키마와 클라이언트 타입을 동기화했습니다. 이 작업으로 대부분의 오류가 해결되었습니다.
notification.repository.ts: Prisma 명명 규칙에 따라 last_notification_check_time을 lastNotificationCheckTime으로 수정했습니다.
prompt.controller.ts: CreatePromptDto의 속성에 접근하는 방식을 동적 인덱싱에서 명시적 속성 접근으로 변경하여 타입 오류를 해결했습니다.
prompt.service.ts: map 콜백 함수의 파라미터에 명시적인 타입을 추가하여 암시적 any 오류를 해결했습니다.