### PR TITLE
Feat: 회원가입 API 구현

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import "./notifications/listeners/notification.listener"; // 알림 리스터 im
 import messageRouter from "./messages/routes/message.route";
 import adminPromptRouter from "./prompts/routes/admin-prompt.route";
 import adminMemberRouter from "./members/routes/admin-member.route";
+import signupRouter from "./signup/routes/signup.route"
 
 const PORT = 3000;
 const app = express();
@@ -87,6 +88,10 @@ app.use(
 );
 
 // 3. 모든 라우터들
+
+// 회원가입 라우터
+app.use("/api/auth/signup", signupRouter);
+
 // 인증 라우터
 app.use("/api/auth", authRouter); // /api 접두사 추가
 

--- a/src/signup/controllers/signup.controller.ts
+++ b/src/signup/controllers/signup.controller.ts
@@ -3,20 +3,55 @@ import { signupService } from "../services/signup.service";
 
 export const signupController = {
   async sendCode(req: Request, res: Response) {
-    const { email } = req.body;
-    await signupService.sendVerificationCode({ email });
-    res.success({ message: "인증번호가 발송되었습니다." });
-  },
+        try {
+            const { email } = req.body;
+            await signupService.sendVerificationCode({ email });
+            res.success({ message: "인증번호가 발송되었습니다." });
+        } catch (error) {
+            if (error instanceof Error) {
+                return res.status(400).fail({ message: error.message });
+            }
+            res.status(500).fail({ message: "인증번호 발송 중 알 수 없는 오류가 발생했습니다." });
+        }
+    },
 
   async verifyCode(req: Request, res: Response) {
-    const { email, code } = req.body;
-    await signupService.verifyCode({ email, code });
-    res.success({ message: "인증이 완료되었습니다." });
-  },
+        try {
+            const { email, code } = req.body;
+            const tempToken = await signupService.verifyCode({ email, code }); 
+            
+            res.success({ 
+                message: "인증이 완료되었습니다. 약관 동의 화면으로 이동합니다.",
+                tempToken: tempToken 
+            });
+        } catch (error) {
+            if (error instanceof Error) {
+                return res.status(400).fail({ message: error.message });
+            }
+            res.status(500).fail({ message: "인증 중 알 수 없는 오류가 발생했습니다." });
+        }
+    },
 
   async register(req: Request, res: Response) {
-    const { email, password } = req.body;
-    const user = await signupService.registerUser({ email, password });
-    res.status(201).success({ message: "회원가입이 완료되었습니다.", user });
-  },
+        const { email, password, consents, tempToken } = req.body; 
+        
+        try {
+            const user = await signupService.registerUser({ 
+                email, 
+                password, 
+                consents,
+                tempToken
+            });
+            
+            res.status(201).success({ 
+                message: "회원가입이 완료되었습니다.", 
+                user 
+            });
+        } catch (error) {
+            if (error instanceof Error) {
+                return res.status(400).fail({ message: error.message });
+            }
+            res.status(500).fail({ message: "회원가입 중 알 수 없는 오류가 발생했습니다." });
+        }
+    },
 };

--- a/src/signup/dtos/signup.dto.ts
+++ b/src/signup/dtos/signup.dto.ts
@@ -10,4 +10,6 @@ export interface VerifyCodeDto {
 export interface RegisterUserDto {
   email: string;
   password: string;
+  consents: { type: string, isAgreed: boolean }[];
+  tempToken: string;
 }

--- a/src/signup/repositories/signup.repository.ts
+++ b/src/signup/repositories/signup.repository.ts
@@ -6,17 +6,29 @@ export const signupRepository = {
     return prisma.user.findUnique({ where: { email } });
   },
 
-  async createUser(email: string, hashedPassword: string) {
-    return prisma.user.create({
+  async createUser(email: string, hashedPassword: string, allConsents: { type: string, isAgreed: boolean }[]) {
+    const newUser = await prisma.user.create({
       data: {
         email,
         password: hashedPassword,
         status: true,
         role: "USER",
         name: '미정', 
-        nickname: 'temp_user_nickname',
+        nickname: 'temp_user_nickname'+ Date.now(),
         social_type: 'NONE',
       },
     });
+
+    const consentRecords = allConsents.map(consent => ({
+        user_id: newUser.user_id,
+        consent_type: consent.type,
+        is_agreed: consent.isAgreed,
+    }));
+    
+    await prisma.userConsent.createMany({
+        data: consentRecords,
+    });
+
+    return newUser;
   },
 };

--- a/src/signup/routes/signup.route.ts
+++ b/src/signup/routes/signup.route.ts
@@ -6,74 +6,98 @@ const router = express.Router();
 /**
  * @swagger
  * tags:
- *   name: SignUp
- *   description: 이메일 인증 기반 회원가입
+ * name: SignUp
+ * description: 이메일 인증 기반 회원가입
  */
 
 /**
  * @swagger
  * /api/auth/signup/send-code:
- *   post:
- *     summary: 이메일 인증번호 발송
- *     tags: [SignUp]
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               email:
- *                 type: string
- *     responses:
- *       200:
- *         description: 인증번호 발송 성공
+ * post:
+ * summary: 이메일 인증번호 발송
+ * tags: [SignUp]
+ * requestBody:
+ * required: true
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * email:
+ * type: string
+ * responses:
+ * 200:
+ * description: 인증번호 발송 성공
  */
 router.post("/send-code", signupController.sendCode);
 
 /**
  * @swagger
  * /api/auth/signup/verify-code:
- *   post:
- *     summary: 인증번호 확인
- *     tags: [SignUp]
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               email:
- *                 type: string
- *               code:
- *                 type: string
- *     responses:
- *       200:
- *         description: 인증 성공
+ * post:
+ * summary: 인증번호 확인 및 임시 토큰 발급
+ * tags: [SignUp]
+ * requestBody:
+ * required: true
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * email:
+ * type: string
+ * code:
+ * type: string
+ * responses:
+ * 200:
+ * description: 인증 성공 및 임시 토큰 발급
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * message:
+ * type: string
+ * tempToken:
+ * type: string
+ * description: 약관 동의 및 최종 회원가입에 사용되는 임시 토큰
  */
 router.post("/verify-code", signupController.verifyCode);
 
 /**
  * @swagger
  * /api/auth/signup/register:
- *   post:
- *     summary: 회원가입 완료 (비밀번호 설정)
- *     tags: [SignUp]
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               email:
- *                 type: string
- *               password:
- *                 type: string
- *     responses:
- *       201:
- *         description: 회원가입 성공
+ * post:
+ * summary: 약관 동의 및 최종 회원가입
+ * tags: [SignUp]
+ * requestBody:
+ * required: true
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * email:
+ * type: string
+ * password:
+ * type: string
+ * format: password
+ * tempToken:
+ * type: string
+ * description: verify-code 응답으로 받은 임시 토큰
+ * consents:
+ * type: array
+ * description: 약관 동의 내역 (필수/선택)
+ * items:
+ * type: object
+ * properties:
+ * type:
+ * type: string
+ * isAgreed:
+ * type: boolean
+ * responses:
+ * 201:
+ * description: 회원가입 성공
  */
 router.post("/register", signupController.register);
 

--- a/src/signup/services/signup.service.ts
+++ b/src/signup/services/signup.service.ts
@@ -2,15 +2,34 @@ import bcrypt from "bcryptjs";
 import { signupRepository } from "../repositories/signup.repository";
 import { SendEmailDto, VerifyCodeDto, RegisterUserDto } from "../dtos/signup.dto";
 import { sendVerificationEmail } from "../../utils/email";
+import { v4 as uuidv4 } from 'uuid';
 
-const emailCodeMap = new Map<string, string>(); // in-memory, 추후 Redis로 대체 가능
+const emailCodeMap = new Map<string, string>();
+const emailTempTokenMap = new Map<string, { token: string, expiry: number }>();
+
+// 비밀번호 정책: 영문 소문자 + 숫자 + 특수문자 + 8자 이상
+function validatePasswordPolicy(password: string): boolean {
+  const regex = /^(?=.*[a-z])(?=.*\d)(?=.*[\W_]).{8,}$/;
+  return regex.test(password);
+}
+
+function generateTempToken(email: string): string {
+    const token = uuidv4();
+    const expiryTime = Date.now() + (10 * 60 * 1000); 
+    emailTempTokenMap.set(email, { token, expiry: expiryTime });
+    
+    return token;
+}
 
 export const signupService = {
   async sendVerificationCode({ email }: SendEmailDto) {
+    const existingUser = await signupRepository.findUserByEmail(email);
+    if (existingUser) throw new Error("이미 가입된 이메일입니다.");
+
     const code = Math.floor(100000 + Math.random() * 900000).toString(); // 6자리
     emailCodeMap.set(email, code);
 
-    await sendVerificationEmail(email, code); // 이메일 발송
+    await sendVerificationEmail(email, code); 
 
     return true;
   },
@@ -20,20 +39,40 @@ export const signupService = {
     if (!savedCode || savedCode !== code) {
       throw new Error("인증번호가 일치하지 않습니다.");
     }
-    return true;
+
+    emailCodeMap.delete(email); 
+    const tempToken = generateTempToken(email); 
+    
+    return tempToken;
   },
 
-  async registerUser({ email, password }: RegisterUserDto) {
+  async registerUser({ email, password, consents, tempToken }: RegisterUserDto) {
+    const tokenData = emailTempTokenMap.get(email);
+
+    if (!tokenData || tokenData.token !== tempToken || tokenData.expiry < Date.now()) {
+     
+      throw new Error("유효하지 않거나 만료된 회원가입 토큰입니다. 인증을 다시 진행해주세요.");
+    }
+    
+    emailTempTokenMap.delete(email);
+
+    const REQUIRED_CONSENTS = [
+        'SERVICE_TERMS_REQUIRED',
+        'PRIVACY_POLICY_REQUIRED',
+        'OVER_14_REQUIRED',
+    ];
+
+    REQUIRED_CONSENTS.forEach(requiredType => {
+        const consent = consents.find(c => c.type === requiredType);
+        if (!consent || !consent.isAgreed) {
+            throw new Error(`필수 약관에 모두 동의해야 합니다.`);
+        }
+    });
+
     const isValid = validatePasswordPolicy(password);
     if (!isValid) throw new Error("비밀번호 정책을 만족하지 않습니다.");
 
     const hashed = await bcrypt.hash(password, 10);
-    return signupRepository.createUser(email, hashed);
+    return signupRepository.createUser(email, hashed, consents);
   },
 };
-
-// 비밀번호 정책: 영문 소문자 + 숫자 + 특수문자 + 8자 이상
-function validatePasswordPolicy(password: string): boolean {
-  const regex = /^(?=.*[a-z])(?=.*\d)(?=.*[\W_]).{8,}$/;
-  return regex.test(password);
-}


### PR DESCRIPTION
## 📌 기능 설명
이 PR은 **이메일 인증 기반 회원가입 기능**을 구현하며, 특히 **보안 강화를 위한 단계별 인증(tempToken)**과 **약관 동의 처리 로직**을 도입합니다.


## 📌 구현 내용
### 1. 단계별 회원가입 플로우 및 보안 강화
* **`tempToken` 기반 단계 제어:** 이메일 인증 성공 후 **`tempToken` (10분 유효)**을 발급하고, 최종 회원가입 (`/register`) 요청 시 이 토큰을 **필수적으로 검증**하도록 하여 무단 접근 및 인증 우회를 차단했습니다.
* **인증 로직 분리:** 기존 회원가입을 3단계 API (`/send-code`, `/verify-code`, `/register`)로 명확히 분리하여 구현했습니다.

### 2. 약관 동의 처리 및 DB 저장
* **필수 약관 검증:** 서비스 레이어(`signupService.registerUser`)에서 **필수 약관 3가지**(`SERVICE_TERMS_REQUIRED`, `PRIVACY_POLICY_REQUIRED`, `OVER_14_REQUIRED`)의 동의 여부를 서버 측에서 강제 검증하도록 구현했습니다.
* **`UserConsent` 활용:** 모든 약관 동의 내역(필수 및 선택 약관)을 확장성 있는 **`UserConsent` 테이블에 저장**하도록 `signupRepository.createUser` 트랜잭션을 구현했습니다.

### 3. SMTP 설정 및 환경 변수 처리
* **Gmail 앱 비밀번호 적용:** Nodemailer 설정 시 보안성이 낮은 일반 비밀번호 대신, **Gmail 앱 비밀번호**를 환경 변수 (`EMAIL_APP_PASSWORD`)를 통해 안전하게 사용하도록 SMTP 설정을 최적화했습니다.

### 4. API 문서(Swagger) 및 에러 처리
* 수정된 API 엔드포인트에 맞춰 **Swagger 정의를 업데이트**하여 `tempToken` 및 `consents` 요청/응답 규격을 명시했습니다.
* Controller에서 `try...catch` 문을 사용하여 `error` 타입을 안전하게 처리(`instanceof Error` 사용)하고, 클라이언트에게 명확한 400 에러 메시지를 반환하도록 개선했습니다.


## 📌 구현 결과
<img width="1195" height="581" alt="image" src="https://github.com/user-attachments/assets/8531fed0-e8cd-42f0-9644-9a323ba48ba6" />
<img width="885" height="551" alt="image" src="https://github.com/user-attachments/assets/d5327c00-1d2e-405e-8fb2-0356cde9f240" />
<img width="1196" height="630" alt="image" src="https://github.com/user-attachments/assets/31428f32-8c3e-4fd0-ae6b-7dc91d90800f" />
<img width="958" height="471" alt="image" src="https://github.com/user-attachments/assets/960f3f0f-abb7-4f16-b24c-8ee7cb68ceea" />
<img width="990" height="555" alt="image" src="https://github.com/user-attachments/assets/b3486360-ace9-4751-b155-efd8e7547868" />

## 📌 논의하고 싶은 점
