### PR TITLE
Bug/#419

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -420,7 +420,6 @@ model Payment {
   purchase_id  Int              @unique
   status       Status
   method       PaymentMethod    
-  provider     PaymentProvider
   merchant_uid String           @unique
   created_at   DateTime         @default(now())
   updated_at   DateTime         @updatedAt

--- a/src/purchases/dtos/purchase.dto.ts
+++ b/src/purchases/dtos/purchase.dto.ts
@@ -1,11 +1,9 @@
-import { PaymentProvider } from "@prisma/client";
 
 export interface PurchaseHistoryItemDTO {
     prompt_id: number;
     title: string;
     price: number;
     seller_nickname: string;
-    pg: PaymentProvider | null;
 }
 
 export interface PurchaseHistoryResponseDTO {

--- a/src/purchases/repositories/purchase.complete.repository.ts
+++ b/src/purchases/repositories/purchase.complete.repository.ts
@@ -1,4 +1,4 @@
-import { Prisma, PaymentMethod, PaymentProvider, Status } from '@prisma/client';
+import { Prisma, PaymentMethod, Status } from '@prisma/client';
 
 type Tx = Prisma.TransactionClient;
 
@@ -17,7 +17,6 @@ export const PurchaseCompleteRepository = {
     purchase_id: number;
     merchant_uid: string;
     method: PaymentMethod;      
-    provider: PaymentProvider;       
     status: Status; 
     paymentId: string;
     cash_receipt_url?: string | null;
@@ -29,7 +28,6 @@ export const PurchaseCompleteRepository = {
         merchant_uid: data.merchant_uid,
         imp_uid: data.paymentId,
         method: data.method,
-        provider: data.provider,
         status: data.status,
         cash_receipt_url: data.cash_receipt_url,
         cash_receipt_type: data.cash_receipt_type,

--- a/src/purchases/repositories/purchase.repository.ts
+++ b/src/purchases/repositories/purchase.repository.ts
@@ -15,11 +15,6 @@ export const PurchaseRepository = {
             user: { select: { nickname: true}},
           },
         },
-        payment: {
-          select: {
-            provider: true,
-          },
-        },
       },
       orderBy: { created_at: 'desc'},
     })

--- a/src/purchases/services/purchase.complete.service.ts
+++ b/src/purchases/services/purchase.complete.service.ts
@@ -48,7 +48,6 @@ export const PurchaseCompleteService = {
             paymentId: paymentId,
             status: 'Succeed',
             method: verifiedPayment.method,     
-            provider: verifiedPayment.provider, 
             cash_receipt_url: verifiedPayment.cashReceipt?.url,
             cash_receipt_type: verifiedPayment.cashReceipt?.type,
         });

--- a/src/purchases/services/purchase.service.ts
+++ b/src/purchases/services/purchase.service.ts
@@ -11,7 +11,6 @@ export const PurchaseHistoryService = {
             price:  r.amount,
             purchased_at: r.created_at.toISOString(),
             seller_nickname: r.prompt.user.nickname,
-            pg: r.payment?.provider ?? null,
         }));
 
         return {

--- a/src/purchases/utils/payment.util.ts
+++ b/src/purchases/utils/payment.util.ts
@@ -1,42 +1,15 @@
 import { PaymentMethod, PaymentProvider } from '@prisma/client'; 
 import { AppError } from '../../errors/AppError';
 
-// 1. 결제 수단 매핑
+// 결제 수단 매핑
 export function normalizePaymentMethod(input: string): PaymentMethod {
   const code = input.toUpperCase().replace(/\s+/g, ''); 
 
-  if (code === 'CARD' || code.includes('카드')) return 'CARD';
-  if (code === 'VIRTUAL_ACCOUNT' || code.includes('가상계좌')) return 'VIRTUAL_ACCOUNT';
-  if (code === 'TRANSFER' || code.includes('계좌이체')) return 'TRANSFER';
-  if (code === 'MOBILE' || code.includes('MOBILE_PHONE') || code.includes('휴대폰')) return 'MOBILE';
-  if (code === 'EASY_PAY' || code.includes('간편결제')) return 'EASY_PAY';
+  if (code === 'PaymentMethodCard') return 'CARD';
+  if (code === 'PaymentMethodVirtualAccount') return 'VIRTUAL_ACCOUNT';
+  if (code === 'PaymentMethodEasyPay') return 'TRANSFER';
+  if (code === 'PaymentMethodTransfer') return 'MOBILE';
+  if (code === 'PaymentMethodMobile') return 'EASY_PAY';
 
   throw new AppError(`지원하지 않는 결제 수단입니다: ${input}`, 400, 'UnsupportedPaymentMethod');
-}
-
-// 2. 제공자 (Provider) 매핑
-export function normalizePaymentProvider(input: string, method: PaymentMethod): PaymentProvider {
-  const code = (input || '').toUpperCase().replace(/\s+/g, '');
-
-  if (code.includes('KAKAO') || code.includes('카카오')) {
-    return 'KAKAOPAY';
-  }
-  if (code.includes('TOSSPAY') || code.includes('토스')) {
-    return 'TOSSPAY';
-  }
-  if (
-    code.includes('NAVER') || code.includes('네이버') ||
-    code.includes('SAMSUNG') || code.includes('삼성') ||
-    code.includes('APPLE') || code.includes('애플') ||
-    code.includes('PAYCO') || code.includes('페이코') ||
-    code.includes('LPAY') || code.includes('엘페이') ||
-    code.includes('SSG') || code.includes('에스에스지') ||
-    code.includes('PINPAY') || code.includes('핀페이')
-  ) {
-    throw new AppError(`현재 지원하지 않는 간편결제사입니다: ${input}`, 400, 'ProviderNotSupported');
-  }
-  if (method !== 'EASY_PAY') {
-      return 'TOSSPAYMENTS';
-  }
-  throw new AppError(`식별할 수 없는 결제 제공자입니다: ${input}`, 400, 'UnknownPaymentProvider');
 }


### PR DESCRIPTION
## 📌 기능 설명
PG사(Provider) 관련 로직을 제거하고, 결제 수단(Method) 매핑 로직을 V2 규격으로 개편했습니다.

## 📌 구현 내용
- Prisma 스키마 업데이트: Payment 모델에서 provider 필드 및 PaymentProvider 참조 제거
- 포트원 V2 응답 매핑 로직 정리: 결제 내역 단건 조회(Verify) 시 포트원 API에서 PG 프로바이더를 추출하여 DB에 매핑하던 함수 및 관련 비즈니스 로직 완전 삭제
- API 응답 DTO 수정: 프롬프트 결제 완료 및 내역 조회 API 응답 구조에서 PG사 정보 반환 로직 제거
- 결제 수단 정규화 유틸 업데이트: normalizePaymentMethod 함수에서 포트원 V2의 method.type (예: PaymentMethodCard) 값을 서버 내부의 PaymentMethod Enum 값으로 변환하도록 수정

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->