### PR TITLE
Fix: Remove leftover provider field in webhook service

### DIFF
--- a/src/purchases/services/purchase.webhook.service.ts
+++ b/src/purchases/services/purchase.webhook.service.ts
@@ -61,7 +61,6 @@ export const WebhookService = {
           purchase_id: purchase.purchase_id,
           merchant_uid: paymentId,
           method: verifiedPayment.method,     
-          provider: verifiedPayment.provider, 
           cash_receipt_url: verifiedPayment.cashReceipt?.url,
           cash_receipt_type: verifiedPayment.cashReceipt?.type,
           status: 'Succeed',


### PR DESCRIPTION
## 📌 기능 설명
웹훅 코드에서 PG사 관련 코드를 제거하여 빌드 오류를 해결했습니다.

## 📌 구현 내용
- src/purchases/services/purchase.webhook.service.ts 내 결제 완료 처리 부분에서 createPaymentTx 함수 호출 시 전달하던 provider 속성 완전 제거

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->