### PR TITLE
feat: 관리자 판매자 목록 조회 및 검색 API 구현

### DIFF
--- a/src/settlements/controllers/admin-seller.controller.ts
+++ b/src/settlements/controllers/admin-seller.controller.ts
@@ -3,10 +3,15 @@ import { AppError } from '../../errors/AppError';
 import {
   approvePendingBusinessSeller,
   getPendingBusinessSellerDetail,
+  listBusinessSellers,
+  listIndividualSellers,
   listPendingBusinessSellers,
   rejectPendingBusinessSeller,
 } from '../services/admin-seller.service';
-import { ListPendingQueryDto } from '../dtos/admin-seller.dto';
+import {
+  ListPendingQueryDto,
+  ListSellersQueryDto,
+} from '../dtos/admin-seller.dto';
 
 const parseUserIdParam = (raw: string): number => {
   const userId = Number(raw);
@@ -73,6 +78,40 @@ export const rejectSeller = async (
     const userId = parseUserIdParam(req.params.userId);
     await rejectPendingBusinessSeller(userId);
     return res.success({ user_id: userId }, '사업자 판매자 등록을 반려했습니다.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getIndividualSellerList = async (
+  req: Request<unknown, unknown, unknown, ListSellersQueryDto>,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const result = await listIndividualSellers(
+      req.query.page,
+      req.query.limit,
+      req.query.search,
+    );
+    return res.success(result, '개인 판매자 목록을 조회했습니다.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getBusinessSellerList = async (
+  req: Request<unknown, unknown, unknown, ListSellersQueryDto>,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const result = await listBusinessSellers(
+      req.query.page,
+      req.query.limit,
+      req.query.search,
+    );
+    return res.success(result, '사업자 판매자 목록을 조회했습니다.');
   } catch (error) {
     return next(error);
   }

--- a/src/settlements/dtos/admin-seller.dto.ts
+++ b/src/settlements/dtos/admin-seller.dto.ts
@@ -36,3 +36,44 @@ export interface PendingSellerDetail extends PendingSellerListItem {
   account_number: string;
   account_holder: string;
 }
+
+export interface ListSellersQueryDto {
+  page?: string;
+  limit?: string;
+  search?: string;
+}
+
+export interface SettlementAccountSummary {
+  bank_code: string;
+  account_number: string;
+  account_holder: string;
+}
+
+export interface IndividualSellerListItem {
+  user_id: number;
+  name: string;
+  email: string;
+  settlement_account: SettlementAccountSummary;
+  created_at: Date;
+}
+
+export interface BusinessSellerListItem {
+  user_id: number;
+  profile_image_url: string | null;
+  nickname: string;
+  name: string;
+  email: string;
+  settlement_account: SettlementAccountSummary;
+  created_at: Date;
+}
+
+export interface SellerListResponse<T> {
+  items: T[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    total_pages: number;
+    has_next: boolean;
+  };
+}

--- a/src/settlements/repositories/admin-seller.repository.ts
+++ b/src/settlements/repositories/admin-seller.repository.ts
@@ -1,8 +1,32 @@
 import prisma from '../../config/prisma';
+import { Prisma } from '@prisma/client';
 
 const pendingBusinessFilter = {
   seller_type: 'BUSINESS' as const,
   status: 'PENDING' as const,
+};
+
+const buildSearchFilter = (search?: string): Prisma.UserWhereInput | undefined => {
+  if (!search) return undefined;
+  return {
+    OR: [
+      { name: { contains: search } },
+      { email: { contains: search } },
+      { nickname: { contains: search } },
+    ],
+  };
+};
+
+const buildApprovedSellerWhere = (
+  sellerType: 'INDIVIDUAL' | 'BUSINESS',
+  search?: string,
+): Prisma.SettlementAccountWhereInput => {
+  const userFilter = buildSearchFilter(search);
+  return {
+    seller_type: sellerType,
+    status: 'APPROVED',
+    ...(userFilter ? { user: userFilter } : {}),
+  };
 };
 
 const userInclude = {
@@ -49,6 +73,30 @@ export const AdminSellerRepository = {
         status,
         is_active: status === 'APPROVED',
       },
+    });
+  },
+
+  findApprovedSellers: async (
+    sellerType: 'INDIVIDUAL' | 'BUSINESS',
+    skip: number,
+    take: number,
+    search?: string,
+  ) => {
+    return prisma.settlementAccount.findMany({
+      where: buildApprovedSellerWhere(sellerType, search),
+      include: userInclude,
+      orderBy: { created_at: 'desc' },
+      skip,
+      take,
+    });
+  },
+
+  countApprovedSellers: async (
+    sellerType: 'INDIVIDUAL' | 'BUSINESS',
+    search?: string,
+  ) => {
+    return prisma.settlementAccount.count({
+      where: buildApprovedSellerWhere(sellerType, search),
     });
   },
 };

--- a/src/settlements/routes/admin-seller.route.ts
+++ b/src/settlements/routes/admin-seller.route.ts
@@ -3,6 +3,8 @@ import { authenticateJwt } from '../../config/passport';
 import { isAdmin } from '../../middlewares/isAdmin';
 import {
   approveSeller,
+  getBusinessSellerList,
+  getIndividualSellerList,
   getPendingSellerDetail,
   getPendingSellerList,
   rejectSeller,
@@ -252,5 +254,162 @@ router.patch(
  *         description: 승인 대기 중인 신청이 존재하지 않음
  */
 router.delete('/pending/:userId', authenticateJwt, isAdmin, rejectSeller);
+
+/**
+ * @swagger
+ * /api/admin/sellers/individual:
+ *   get:
+ *     summary: 개인 판매자 목록 조회 / 검색
+ *     description: 관리자가 승인 완료(`APPROVED`) 상태의 개인 판매자 목록을 조회합니다. `search` 파라미터로 실명/이메일/닉네임 부분 일치 검색이 가능합니다.
+ *     tags: [AdminSeller]
+ *     security:
+ *       - jwt: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: 페이지 번호
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 50
+ *           default: 10
+ *         description: 페이지 당 항목 수
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: 실명, 이메일, 닉네임 부분 일치 검색어
+ *     responses:
+ *       200:
+ *         description: 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 개인 판매자 목록을 조회했습니다.
+ *                 statusCode:
+ *                   type: integer
+ *                   example: 200
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     items:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           user_id: { type: integer, example: 12 }
+ *                           name: { type: string, example: 홍길동 }
+ *                           email: { type: string, example: gildong@example.com }
+ *                           settlement_account:
+ *                             type: object
+ *                             properties:
+ *                               bank_code: { type: string, example: KOOKMIN }
+ *                               account_number: { type: string, example: "1234567890" }
+ *                               account_holder: { type: string, example: 홍길동 }
+ *                           created_at: { type: string, format: date-time }
+ *                     pagination:
+ *                       type: object
+ *                       properties:
+ *                         page: { type: integer, example: 1 }
+ *                         limit: { type: integer, example: 10 }
+ *                         total: { type: integer, example: 23 }
+ *                         total_pages: { type: integer, example: 3 }
+ *                         has_next: { type: boolean, example: true }
+ *       401:
+ *         description: 인증 실패
+ *       403:
+ *         description: 권한 없음
+ */
+router.get('/individual', authenticateJwt, isAdmin, getIndividualSellerList);
+
+/**
+ * @swagger
+ * /api/admin/sellers/business:
+ *   get:
+ *     summary: 사업자 판매자 목록 조회 / 검색
+ *     description: 관리자가 승인 완료(`APPROVED`) 상태의 사업자 판매자 목록을 조회합니다. `search` 파라미터로 실명/이메일/닉네임 부분 일치 검색이 가능합니다.
+ *     tags: [AdminSeller]
+ *     security:
+ *       - jwt: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 50
+ *           default: 10
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: 실명, 이메일, 닉네임 부분 일치 검색어
+ *     responses:
+ *       200:
+ *         description: 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 사업자 판매자 목록을 조회했습니다.
+ *                 statusCode:
+ *                   type: integer
+ *                   example: 200
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     items:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           user_id: { type: integer, example: 12 }
+ *                           profile_image_url:
+ *                             type: string
+ *                             nullable: true
+ *                             example: https://cdn.example.com/users/12.png
+ *                           nickname: { type: string, example: gildong }
+ *                           name: { type: string, example: 홍길동 }
+ *                           email: { type: string, example: gildong@example.com }
+ *                           settlement_account:
+ *                             type: object
+ *                             properties:
+ *                               bank_code: { type: string, example: KOOKMIN }
+ *                               account_number: { type: string, example: "1234567890" }
+ *                               account_holder: { type: string, example: 홍길동 }
+ *                           created_at: { type: string, format: date-time }
+ *                     pagination:
+ *                       type: object
+ *                       properties:
+ *                         page: { type: integer, example: 1 }
+ *                         limit: { type: integer, example: 10 }
+ *                         total: { type: integer, example: 23 }
+ *                         total_pages: { type: integer, example: 3 }
+ *                         has_next: { type: boolean, example: true }
+ *       401:
+ *         description: 인증 실패
+ *       403:
+ *         description: 권한 없음
+ */
+router.get('/business', authenticateJwt, isAdmin, getBusinessSellerList);
 
 export default router;

--- a/src/settlements/services/admin-seller.service.ts
+++ b/src/settlements/services/admin-seller.service.ts
@@ -1,9 +1,12 @@
 import { AdminSellerRepository } from '../repositories/admin-seller.repository';
 import { AppError } from '../../errors/AppError';
 import {
+  BusinessSellerListItem,
+  IndividualSellerListItem,
   PendingSellerDetail,
   PendingSellerListItem,
   PendingSellerListResponse,
+  SellerListResponse,
 } from '../dtos/admin-seller.dto';
 
 const DEFAULT_PAGE = 1;
@@ -124,4 +127,96 @@ export const rejectPendingBusinessSeller = async (userId: number) => {
   }
 
   await AdminSellerRepository.updateBusinessSellerStatus(userId, 'REJECTED');
+};
+
+const normalizeSearch = (search?: string): string | undefined => {
+  const trimmed = search?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+};
+
+const toSettlementAccountSummary = (account: NonNullable<SellerWithUser>) => ({
+  bank_code: account.bank_code,
+  account_number: account.account_number,
+  account_holder: account.account_holder,
+});
+
+const toIndividualListItem = (
+  account: NonNullable<SellerWithUser>,
+): IndividualSellerListItem => ({
+  user_id: account.user.user_id,
+  name: account.user.name,
+  email: account.user.email,
+  settlement_account: toSettlementAccountSummary(account),
+  created_at: account.created_at,
+});
+
+const toBusinessListItem = (
+  account: NonNullable<SellerWithUser>,
+): BusinessSellerListItem => ({
+  user_id: account.user.user_id,
+  profile_image_url: account.user.profileImage?.url ?? null,
+  nickname: account.user.nickname,
+  name: account.user.name,
+  email: account.user.email,
+  settlement_account: toSettlementAccountSummary(account),
+  created_at: account.created_at,
+});
+
+const buildPagination = (page: number, limit: number, total: number) => {
+  const totalPages = total === 0 ? 0 : Math.ceil(total / limit);
+  return {
+    page,
+    limit,
+    total,
+    total_pages: totalPages,
+    has_next: page < totalPages,
+  };
+};
+
+export const listIndividualSellers = async (
+  pageParam?: string,
+  limitParam?: string,
+  searchParam?: string,
+): Promise<SellerListResponse<IndividualSellerListItem>> => {
+  const { page, limit } = parsePagination(pageParam, limitParam);
+  const search = normalizeSearch(searchParam);
+
+  const [accounts, total] = await Promise.all([
+    AdminSellerRepository.findApprovedSellers(
+      'INDIVIDUAL',
+      (page - 1) * limit,
+      limit,
+      search,
+    ),
+    AdminSellerRepository.countApprovedSellers('INDIVIDUAL', search),
+  ]);
+
+  return {
+    items: accounts.map(toIndividualListItem),
+    pagination: buildPagination(page, limit, total),
+  };
+};
+
+export const listBusinessSellers = async (
+  pageParam?: string,
+  limitParam?: string,
+  searchParam?: string,
+): Promise<SellerListResponse<BusinessSellerListItem>> => {
+  const { page, limit } = parsePagination(pageParam, limitParam);
+  const search = normalizeSearch(searchParam);
+
+  const [accounts, total] = await Promise.all([
+    AdminSellerRepository.findApprovedSellers(
+      'BUSINESS',
+      (page - 1) * limit,
+      limit,
+      search,
+    ),
+    AdminSellerRepository.countApprovedSellers('BUSINESS', search),
+  ]);
+
+  return {
+    items: accounts.map(toBusinessListItem),
+    pagination: buildPagination(page, limit, total),
+  };
 };

--- a/swagger.json
+++ b/swagger.json
@@ -6188,6 +6188,301 @@
         }
       }
     },
+    "/api/admin/sellers/individual": {
+      "get": {
+        "summary": "개인 판매자 목록 조회 / 검색",
+        "description": "관리자가 승인 완료(`APPROVED`) 상태의 개인 판매자 목록을 조회합니다. `search` 파라미터로 실명/이메일/닉네임 부분 일치 검색이 가능합니다.",
+        "tags": [
+          "AdminSeller"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "description": "페이지 번호"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            },
+            "description": "페이지 당 항목 수"
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            },
+            "description": "실명, 이메일, 닉네임 부분 일치 검색어"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "개인 판매자 목록을 조회했습니다."
+                    },
+                    "statusCode": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "user_id": {
+                                "type": "integer",
+                                "example": 12
+                              },
+                              "name": {
+                                "type": "string",
+                                "example": "홍길동"
+                              },
+                              "email": {
+                                "type": "string",
+                                "example": "gildong@example.com"
+                              },
+                              "settlement_account": {
+                                "type": "object",
+                                "properties": {
+                                  "bank_code": {
+                                    "type": "string",
+                                    "example": "KOOKMIN"
+                                  },
+                                  "account_number": {
+                                    "type": "string",
+                                    "example": "1234567890"
+                                  },
+                                  "account_holder": {
+                                    "type": "string",
+                                    "example": "홍길동"
+                                  }
+                                }
+                              },
+                              "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            }
+                          }
+                        },
+                        "pagination": {
+                          "type": "object",
+                          "properties": {
+                            "page": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "limit": {
+                              "type": "integer",
+                              "example": 10
+                            },
+                            "total": {
+                              "type": "integer",
+                              "example": 23
+                            },
+                            "total_pages": {
+                              "type": "integer",
+                              "example": 3
+                            },
+                            "has_next": {
+                              "type": "boolean",
+                              "example": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패"
+          },
+          "403": {
+            "description": "권한 없음"
+          }
+        }
+      }
+    },
+    "/api/admin/sellers/business": {
+      "get": {
+        "summary": "사업자 판매자 목록 조회 / 검색",
+        "description": "관리자가 승인 완료(`APPROVED`) 상태의 사업자 판매자 목록을 조회합니다. `search` 파라미터로 실명/이메일/닉네임 부분 일치 검색이 가능합니다.",
+        "tags": [
+          "AdminSeller"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            },
+            "description": "실명, 이메일, 닉네임 부분 일치 검색어"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "사업자 판매자 목록을 조회했습니다."
+                    },
+                    "statusCode": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "user_id": {
+                                "type": "integer",
+                                "example": 12
+                              },
+                              "profile_image_url": {
+                                "type": "string",
+                                "nullable": true,
+                                "example": "https://cdn.example.com/users/12.png"
+                              },
+                              "nickname": {
+                                "type": "string",
+                                "example": "gildong"
+                              },
+                              "name": {
+                                "type": "string",
+                                "example": "홍길동"
+                              },
+                              "email": {
+                                "type": "string",
+                                "example": "gildong@example.com"
+                              },
+                              "settlement_account": {
+                                "type": "object",
+                                "properties": {
+                                  "bank_code": {
+                                    "type": "string",
+                                    "example": "KOOKMIN"
+                                  },
+                                  "account_number": {
+                                    "type": "string",
+                                    "example": "1234567890"
+                                  },
+                                  "account_holder": {
+                                    "type": "string",
+                                    "example": "홍길동"
+                                  }
+                                }
+                              },
+                              "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            }
+                          }
+                        },
+                        "pagination": {
+                          "type": "object",
+                          "properties": {
+                            "page": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "limit": {
+                              "type": "integer",
+                              "example": 10
+                            },
+                            "total": {
+                              "type": "integer",
+                              "example": 23
+                            },
+                            "total_pages": {
+                              "type": "integer",
+                              "example": 3
+                            },
+                            "has_next": {
+                              "type": "boolean",
+                              "example": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패"
+          },
+          "403": {
+            "description": "권한 없음"
+          }
+        }
+      }
+    },
     "/api/settlements/accounts": {
       "get": {
         "summary": "등록된 정산 계좌 정보 조회",


### PR DESCRIPTION
## 📌 기능 설명
관리자 대시보드에서 승인 완료된 개인/사업자 판매자 목록을 조회하고 검색하는 API를 구현합니다.
관련 이슈: #452

## 📌 구현 내용

### 추가된 엔드포인트 (모두 `authenticateJwt` + `isAdmin` 적용)

| 메서드 | 경로 | 동작 |
|--------|------|------|
| `GET` | `/api/admin/sellers/individual` | 개인 판매자 목록 (실명·이메일·정산계좌) |
| `GET` | `/api/admin/sellers/business` | 사업자 판매자 목록 (프로필·닉네임·실명·이메일·정산계좌) |

**공통 쿼리 파라미터**
- `page` (default 1), `limit` (default 10, max 50)
- `search`: 실명(`User.name`) · 이메일(`User.email`) · 닉네임(`User.nickname`) 부분 일치 검색

### 설계 결정
- **상태 필터**: `status=APPROVED`만 조회 (대기는 `/api/admin/sellers/pending`, 반려는 목록에서 제외)
- **정렬**: `created_at DESC` (#451과 동일하게 가입 최신순)
- **검색 정규화**: 공백 trim 후 빈 문자열이면 검색 미적용
- **응답 포맷**: 개인은 spec대로 lean하게, 사업자는 프로필/닉네임 포함 (`PendingSeller` 응답과 일관성 유지)

### 변경 파일
- `src/settlements/dtos/admin-seller.dto.ts` — `IndividualSellerListItem`, `BusinessSellerListItem`, `SellerListResponse<T>` 추가
- `src/settlements/repositories/admin-seller.repository.ts` — `findApprovedSellers`, `countApprovedSellers` + 검색 필터 빌더
- `src/settlements/services/admin-seller.service.ts` — `listIndividualSellers`, `listBusinessSellers`
- `src/settlements/controllers/admin-seller.controller.ts` — `getIndividualSellerList`, `getBusinessSellerList`
- `src/settlements/routes/admin-seller.route.ts` — 2개 라우트 + Swagger 문서
- `swagger.json` — 빌드 시 자동 재생성

## 📌 구현 결과
- `pnpm exec tsc --noEmit` 통과
- `pnpm build` 통과
- Swagger `/api-docs` → `AdminSeller` 태그에서 신규 2개 API 확인 가능

## 📌 논의하고 싶은 점
- 검색 매칭 방식: 현재 `contains` 사용 (MySQL의 `utf8mb4_general_ci`/`utf8mb4_unicode_ci` 콜레이션에서는 기본적으로 대소문자 무시). 완전 일치/접두사 일치 등이 필요하면 알려주세요
- 개인 판매자 응답에 프로필 사진/닉네임을 포함시킬지 — 현재는 기획서대로 미포함. 프론트 통합 시 필요해지면 확장 가능