### PR TITLE
feat: 관리자 판매자 상세 조회 API 구현

### DIFF
--- a/src/settlements/controllers/admin-seller.controller.ts
+++ b/src/settlements/controllers/admin-seller.controller.ts
@@ -2,6 +2,8 @@ import { Request, Response, NextFunction } from 'express';
 import { AppError } from '../../errors/AppError';
 import {
   approvePendingBusinessSeller,
+  getBusinessSellerDetail,
+  getIndividualSellerDetail,
   getPendingBusinessSellerDetail,
   listBusinessSellers,
   listIndividualSellers,
@@ -112,6 +114,34 @@ export const getBusinessSellerList = async (
       req.query.search,
     );
     return res.success(result, '사업자 판매자 목록을 조회했습니다.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getIndividualSellerDetailHandler = async (
+  req: Request<{ userId: string }>,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const userId = parseUserIdParam(req.params.userId);
+    const result = await getIndividualSellerDetail(userId);
+    return res.success(result, '개인 판매자 상세 정보를 조회했습니다.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getBusinessSellerDetailHandler = async (
+  req: Request<{ userId: string }>,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const userId = parseUserIdParam(req.params.userId);
+    const result = await getBusinessSellerDetail(userId);
+    return res.success(result, '사업자 판매자 상세 정보를 조회했습니다.');
   } catch (error) {
     return next(error);
   }

--- a/src/settlements/dtos/admin-seller.dto.ts
+++ b/src/settlements/dtos/admin-seller.dto.ts
@@ -77,3 +77,31 @@ export interface SellerListResponse<T> {
     has_next: boolean;
   };
 }
+
+export interface IndividualSellerDetail {
+  user_id: number;
+  profile_image_url: string | null;
+  nickname: string;
+  name: string;
+  email: string;
+  registration_type: 'INDIVIDUAL';
+  settlement_account: SettlementAccountSummary;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface BusinessSellerDetail {
+  user_id: number;
+  profile_image_url: string | null;
+  nickname: string;
+  name: string;
+  email: string;
+  registration_type: 'BUSINESS';
+  business_number: string | null;
+  representative_name: string | null;
+  company_name: string | null;
+  business_license_url: string | null;
+  settlement_account: SettlementAccountSummary;
+  created_at: Date;
+  updated_at: Date;
+}

--- a/src/settlements/repositories/admin-seller.repository.ts
+++ b/src/settlements/repositories/admin-seller.repository.ts
@@ -99,4 +99,18 @@ export const AdminSellerRepository = {
       where: buildApprovedSellerWhere(sellerType, search),
     });
   },
+
+  findApprovedSellerByUserId: async (
+    sellerType: 'INDIVIDUAL' | 'BUSINESS',
+    userId: number,
+  ) => {
+    return prisma.settlementAccount.findFirst({
+      where: {
+        seller_type: sellerType,
+        status: 'APPROVED',
+        user_id: userId,
+      },
+      include: userInclude,
+    });
+  },
 };

--- a/src/settlements/routes/admin-seller.route.ts
+++ b/src/settlements/routes/admin-seller.route.ts
@@ -3,7 +3,9 @@ import { authenticateJwt } from '../../config/passport';
 import { isAdmin } from '../../middlewares/isAdmin';
 import {
   approveSeller,
+  getBusinessSellerDetailHandler,
   getBusinessSellerList,
+  getIndividualSellerDetailHandler,
   getIndividualSellerList,
   getPendingSellerDetail,
   getPendingSellerList,
@@ -411,5 +413,138 @@ router.get('/individual', authenticateJwt, isAdmin, getIndividualSellerList);
  *         description: 권한 없음
  */
 router.get('/business', authenticateJwt, isAdmin, getBusinessSellerList);
+
+/**
+ * @swagger
+ * /api/admin/sellers/individual/{userId}:
+ *   get:
+ *     summary: 개인 판매자 상세 조회
+ *     description: 관리자가 승인 완료(`APPROVED`)된 개인 판매자의 상세 정보를 조회합니다.
+ *     tags: [AdminSeller]
+ *     security:
+ *       - jwt: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: 사용자 ID
+ *     responses:
+ *       200:
+ *         description: 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 개인 판매자 상세 정보를 조회했습니다.
+ *                 statusCode:
+ *                   type: integer
+ *                   example: 200
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     user_id: { type: integer, example: 12 }
+ *                     profile_image_url: { type: string, nullable: true }
+ *                     nickname: { type: string, example: gildong }
+ *                     name: { type: string, example: 홍길동 }
+ *                     email: { type: string, example: gildong@example.com }
+ *                     registration_type: { type: string, example: INDIVIDUAL }
+ *                     settlement_account:
+ *                       type: object
+ *                       properties:
+ *                         bank_code: { type: string, example: KOOKMIN }
+ *                         account_number: { type: string, example: "1234567890" }
+ *                         account_holder: { type: string, example: 홍길동 }
+ *                     created_at: { type: string, format: date-time }
+ *                     updated_at: { type: string, format: date-time }
+ *       400:
+ *         description: 유효하지 않은 사용자 ID
+ *       401:
+ *         description: 인증 실패
+ *       403:
+ *         description: 권한 없음
+ *       404:
+ *         description: 승인 완료된 개인 판매자 정보가 존재하지 않음
+ */
+router.get(
+  '/individual/:userId',
+  authenticateJwt,
+  isAdmin,
+  getIndividualSellerDetailHandler,
+);
+
+/**
+ * @swagger
+ * /api/admin/sellers/business/{userId}:
+ *   get:
+ *     summary: 사업자 판매자 상세 조회
+ *     description: 관리자가 승인 완료(`APPROVED`)된 사업자 판매자의 상세 정보를 조회합니다. 사업자등록증 URL과 사업자 정보를 포함합니다.
+ *     tags: [AdminSeller]
+ *     security:
+ *       - jwt: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: 사용자 ID
+ *     responses:
+ *       200:
+ *         description: 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 사업자 판매자 상세 정보를 조회했습니다.
+ *                 statusCode:
+ *                   type: integer
+ *                   example: 200
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     user_id: { type: integer, example: 12 }
+ *                     profile_image_url: { type: string, nullable: true }
+ *                     nickname: { type: string, example: gildong }
+ *                     name: { type: string, example: 홍길동 }
+ *                     email: { type: string, example: gildong@example.com }
+ *                     registration_type: { type: string, example: BUSINESS }
+ *                     business_number: { type: string, nullable: true, example: "123-45-67890" }
+ *                     representative_name: { type: string, nullable: true, example: 홍길동 }
+ *                     company_name: { type: string, nullable: true, example: 홍길동컴퍼니 }
+ *                     business_license_url:
+ *                       type: string
+ *                       nullable: true
+ *                       example: https://s3.example.com/licenses/12.pdf
+ *                     settlement_account:
+ *                       type: object
+ *                       properties:
+ *                         bank_code: { type: string }
+ *                         account_number: { type: string }
+ *                         account_holder: { type: string }
+ *                     created_at: { type: string, format: date-time }
+ *                     updated_at: { type: string, format: date-time }
+ *       400:
+ *         description: 유효하지 않은 사용자 ID
+ *       401:
+ *         description: 인증 실패
+ *       403:
+ *         description: 권한 없음
+ *       404:
+ *         description: 승인 완료된 사업자 판매자 정보가 존재하지 않음
+ */
+router.get(
+  '/business/:userId',
+  authenticateJwt,
+  isAdmin,
+  getBusinessSellerDetailHandler,
+);
 
 export default router;

--- a/src/settlements/services/admin-seller.service.ts
+++ b/src/settlements/services/admin-seller.service.ts
@@ -1,7 +1,9 @@
 import { AdminSellerRepository } from '../repositories/admin-seller.repository';
 import { AppError } from '../../errors/AppError';
 import {
+  BusinessSellerDetail,
   BusinessSellerListItem,
+  IndividualSellerDetail,
   IndividualSellerListItem,
   PendingSellerDetail,
   PendingSellerListItem,
@@ -218,5 +220,76 @@ export const listBusinessSellers = async (
   return {
     items: accounts.map(toBusinessListItem),
     pagination: buildPagination(page, limit, total),
+  };
+};
+
+const sellerNotFound = (sellerType: 'INDIVIDUAL' | 'BUSINESS') => {
+  const label = sellerType === 'INDIVIDUAL' ? '개인' : '사업자';
+  return new AppError(
+    `해당 사용자의 승인 완료된 ${label} 판매자 등록 정보가 존재하지 않습니다.`,
+    404,
+    'SellerNotFound',
+  );
+};
+
+export const getIndividualSellerDetail = async (
+  userId: number,
+): Promise<IndividualSellerDetail> => {
+  const account = await AdminSellerRepository.findApprovedSellerByUserId(
+    'INDIVIDUAL',
+    userId,
+  );
+
+  if (!account) {
+    throw sellerNotFound('INDIVIDUAL');
+  }
+
+  return {
+    user_id: account.user.user_id,
+    profile_image_url: account.user.profileImage?.url ?? null,
+    nickname: account.user.nickname,
+    name: account.user.name,
+    email: account.user.email,
+    registration_type: 'INDIVIDUAL',
+    settlement_account: {
+      bank_code: account.bank_code,
+      account_number: account.account_number,
+      account_holder: account.account_holder,
+    },
+    created_at: account.created_at,
+    updated_at: account.updated_at,
+  };
+};
+
+export const getBusinessSellerDetail = async (
+  userId: number,
+): Promise<BusinessSellerDetail> => {
+  const account = await AdminSellerRepository.findApprovedSellerByUserId(
+    'BUSINESS',
+    userId,
+  );
+
+  if (!account) {
+    throw sellerNotFound('BUSINESS');
+  }
+
+  return {
+    user_id: account.user.user_id,
+    profile_image_url: account.user.profileImage?.url ?? null,
+    nickname: account.user.nickname,
+    name: account.user.name,
+    email: account.user.email,
+    registration_type: 'BUSINESS',
+    business_number: account.business_number,
+    representative_name: account.representative_name,
+    company_name: account.company_name,
+    business_license_url: account.business_license_url,
+    settlement_account: {
+      bank_code: account.bank_code,
+      account_number: account.account_number,
+      account_holder: account.account_holder,
+    },
+    created_at: account.created_at,
+    updated_at: account.updated_at,
   };
 };

--- a/swagger.json
+++ b/swagger.json
@@ -6483,6 +6483,249 @@
         }
       }
     },
+    "/api/admin/sellers/individual/{userId}": {
+      "get": {
+        "summary": "개인 판매자 상세 조회",
+        "description": "관리자가 승인 완료(`APPROVED`)된 개인 판매자의 상세 정보를 조회합니다.",
+        "tags": [
+          "AdminSeller"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "사용자 ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "개인 판매자 상세 정보를 조회했습니다."
+                    },
+                    "statusCode": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "user_id": {
+                          "type": "integer",
+                          "example": 12
+                        },
+                        "profile_image_url": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "nickname": {
+                          "type": "string",
+                          "example": "gildong"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "홍길동"
+                        },
+                        "email": {
+                          "type": "string",
+                          "example": "gildong@example.com"
+                        },
+                        "registration_type": {
+                          "type": "string",
+                          "example": "INDIVIDUAL"
+                        },
+                        "settlement_account": {
+                          "type": "object",
+                          "properties": {
+                            "bank_code": {
+                              "type": "string",
+                              "example": "KOOKMIN"
+                            },
+                            "account_number": {
+                              "type": "string",
+                              "example": "1234567890"
+                            },
+                            "account_holder": {
+                              "type": "string",
+                              "example": "홍길동"
+                            }
+                          }
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "유효하지 않은 사용자 ID"
+          },
+          "401": {
+            "description": "인증 실패"
+          },
+          "403": {
+            "description": "권한 없음"
+          },
+          "404": {
+            "description": "승인 완료된 개인 판매자 정보가 존재하지 않음"
+          }
+        }
+      }
+    },
+    "/api/admin/sellers/business/{userId}": {
+      "get": {
+        "summary": "사업자 판매자 상세 조회",
+        "description": "관리자가 승인 완료(`APPROVED`)된 사업자 판매자의 상세 정보를 조회합니다. 사업자등록증 URL과 사업자 정보를 포함합니다.",
+        "tags": [
+          "AdminSeller"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "사용자 ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "사업자 판매자 상세 정보를 조회했습니다."
+                    },
+                    "statusCode": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "user_id": {
+                          "type": "integer",
+                          "example": 12
+                        },
+                        "profile_image_url": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "nickname": {
+                          "type": "string",
+                          "example": "gildong"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "홍길동"
+                        },
+                        "email": {
+                          "type": "string",
+                          "example": "gildong@example.com"
+                        },
+                        "registration_type": {
+                          "type": "string",
+                          "example": "BUSINESS"
+                        },
+                        "business_number": {
+                          "type": "string",
+                          "nullable": true,
+                          "example": "123-45-67890"
+                        },
+                        "representative_name": {
+                          "type": "string",
+                          "nullable": true,
+                          "example": "홍길동"
+                        },
+                        "company_name": {
+                          "type": "string",
+                          "nullable": true,
+                          "example": "홍길동컴퍼니"
+                        },
+                        "business_license_url": {
+                          "type": "string",
+                          "nullable": true,
+                          "example": "https://s3.example.com/licenses/12.pdf"
+                        },
+                        "settlement_account": {
+                          "type": "object",
+                          "properties": {
+                            "bank_code": {
+                              "type": "string"
+                            },
+                            "account_number": {
+                              "type": "string"
+                            },
+                            "account_holder": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "유효하지 않은 사용자 ID"
+          },
+          "401": {
+            "description": "인증 실패"
+          },
+          "403": {
+            "description": "권한 없음"
+          },
+          "404": {
+            "description": "승인 완료된 사업자 판매자 정보가 존재하지 않음"
+          }
+        }
+      }
+    },
     "/api/settlements/accounts": {
       "get": {
         "summary": "등록된 정산 계좌 정보 조회",


### PR DESCRIPTION
## 📌 기능 설명
관리자 대시보드의 "등록 폼 보기" 영역에서 사용할 개인/사업자 판매자 상세 조회 API를 구현합니다.
관련 이슈: #453

## 📌 구현 내용

### 추가된 엔드포인트 (모두 `authenticateJwt` + `isAdmin` 적용)

| 메서드 | 경로 | 동작 |
|--------|------|------|
| `GET` | `/api/admin/sellers/individual/:userId` | 개인 판매자 상세 |
| `GET` | `/api/admin/sellers/business/:userId` | 사업자 판매자 상세 |

### 응답 필드
- **개인**: `user_id`, `profile_image_url`, `nickname`, `name`, `email`, `registration_type=INDIVIDUAL`, `settlement_account(bank_code/account_number/account_holder)`, `created_at`, `updated_at`
- **사업자**: 개인 필드 + `business_number`, `representative_name`, `company_name`, `business_license_url` (등록유형 `BUSINESS`)

### 설계 결정
- **상태 필터**: `status=APPROVED`만 조회 (PENDING은 별도 `/pending/:userId` 사용)
- **계좌 마스킹 없음**: 관리자 검증 목적이므로 풀 노출
- **DTO 분리**: 개인/사업자 응답 인터페이스를 명확히 분리하여 타입 안전성 확보
- **404 처리**: `seller_type` 불일치/미등록 모두 `SellerNotFound` 에러로 통일

### 변경 파일
- `src/settlements/dtos/admin-seller.dto.ts` — `IndividualSellerDetail`, `BusinessSellerDetail` 추가
- `src/settlements/repositories/admin-seller.repository.ts` — `findApprovedSellerByUserId` 추가
- `src/settlements/services/admin-seller.service.ts` — `getIndividualSellerDetail`, `getBusinessSellerDetail`
- `src/settlements/controllers/admin-seller.controller.ts` — 핸들러 2개 추가
- `src/settlements/routes/admin-seller.route.ts` — 2개 라우트 + Swagger 문서
- `swagger.json` — 빌드 시 자동 재생성

## 📌 구현 결과
- `pnpm build` 통과 (tsc 0 errors)
- Swagger `/api-docs` → `AdminSeller` 태그에 신규 2개 API 표시

## 📌 논의하고 싶은 점
- 사업자 상세 응답의 nullable 필드(`business_number` 등)들 — 승인 완료 상태라면 사실상 모두 값이 있을 텐데, 스키마상 nullable이라 타입은 그대로 유지함. 추후 NOT NULL 마이그레이션 검토 가능
- 추후 정산계좌 마스킹 정책 필요 시 응답 transformer만 교체하면 됨