### PR TITLE
feat: 관리자 판매자 등록 취소 API 구현

### DIFF
--- a/src/settlements/controllers/admin-seller.controller.ts
+++ b/src/settlements/controllers/admin-seller.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { AppError } from '../../errors/AppError';
 import {
   approvePendingBusinessSeller,
+  cancelSeller,
   getBusinessSellerDetail,
   getIndividualSellerDetail,
   getPendingBusinessSellerDetail,
@@ -142,6 +143,20 @@ export const getBusinessSellerDetailHandler = async (
     const userId = parseUserIdParam(req.params.userId);
     const result = await getBusinessSellerDetail(userId);
     return res.success(result, '사업자 판매자 상세 정보를 조회했습니다.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const cancelSellerHandler = async (
+  req: Request<{ userId: string }>,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const userId = parseUserIdParam(req.params.userId);
+    const result = await cancelSeller(userId);
+    return res.success(result, '판매자 등록을 취소했습니다.');
   } catch (error) {
     return next(error);
   }

--- a/src/settlements/dtos/admin-seller.dto.ts
+++ b/src/settlements/dtos/admin-seller.dto.ts
@@ -105,3 +105,8 @@ export interface BusinessSellerDetail {
   created_at: Date;
   updated_at: Date;
 }
+
+export interface SellerCancellationResult {
+  user_id: number;
+  deactivated_prompt_count: number;
+}

--- a/src/settlements/repositories/admin-seller.repository.ts
+++ b/src/settlements/repositories/admin-seller.repository.ts
@@ -113,4 +113,23 @@ export const AdminSellerRepository = {
       include: userInclude,
     });
   },
+
+  findApprovedSellerAnyType: async (userId: number) => {
+    return prisma.settlementAccount.findFirst({
+      where: { user_id: userId, status: 'APPROVED' },
+    });
+  },
+
+  cancelSellerTransaction: async (userId: number) => {
+    const [deactivatedPrompts] = await prisma.$transaction([
+      prisma.prompt.updateMany({
+        where: { user_id: userId, inactive_date: null },
+        data: { inactive_date: new Date() },
+      }),
+      prisma.settlementAccount.delete({
+        where: { user_id: userId },
+      }),
+    ]);
+    return { deactivated_prompt_count: deactivatedPrompts.count };
+  },
 };

--- a/src/settlements/routes/admin-seller.route.ts
+++ b/src/settlements/routes/admin-seller.route.ts
@@ -3,6 +3,7 @@ import { authenticateJwt } from '../../config/passport';
 import { isAdmin } from '../../middlewares/isAdmin';
 import {
   approveSeller,
+  cancelSellerHandler,
   getBusinessSellerDetailHandler,
   getBusinessSellerList,
   getIndividualSellerDetailHandler,
@@ -546,5 +547,58 @@ router.get(
   isAdmin,
   getBusinessSellerDetailHandler,
 );
+
+/**
+ * @swagger
+ * /api/admin/sellers/{userId}:
+ *   delete:
+ *     summary: 판매자 등록 취소
+ *     description: |
+ *       관리자가 승인 완료(`APPROVED`) 상태의 판매자(개인/사업자 공통) 등록을 취소합니다.
+ *       다음 작업이 트랜잭션으로 함께 수행됩니다.
+ *
+ *       - 사용자의 활성 프롬프트 일괄 비활성화 (`Prompt.inactive_date = now()`)
+ *       - `SettlementAccount` 레코드 하드 삭제
+ *
+ *       기존 구매/정산 이력은 영향받지 않습니다.
+ *     tags: [AdminSeller]
+ *     security:
+ *       - jwt: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: 사용자 ID
+ *     responses:
+ *       200:
+ *         description: 취소 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 판매자 등록을 취소했습니다.
+ *                 statusCode:
+ *                   type: integer
+ *                   example: 200
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     user_id: { type: integer, example: 12 }
+ *                     deactivated_prompt_count: { type: integer, example: 5 }
+ *       400:
+ *         description: 유효하지 않은 사용자 ID
+ *       401:
+ *         description: 인증 실패
+ *       403:
+ *         description: 권한 없음
+ *       404:
+ *         description: 승인 완료된 판매자가 아님
+ */
+router.delete('/:userId', authenticateJwt, isAdmin, cancelSellerHandler);
 
 export default router;

--- a/src/settlements/services/admin-seller.service.ts
+++ b/src/settlements/services/admin-seller.service.ts
@@ -8,6 +8,7 @@ import {
   PendingSellerDetail,
   PendingSellerListItem,
   PendingSellerListResponse,
+  SellerCancellationResult,
   SellerListResponse,
 } from '../dtos/admin-seller.dto';
 
@@ -292,4 +293,23 @@ export const getBusinessSellerDetail = async (
     created_at: account.created_at,
     updated_at: account.updated_at,
   };
+};
+
+export const cancelSeller = async (
+  userId: number,
+): Promise<SellerCancellationResult> => {
+  const account = await AdminSellerRepository.findApprovedSellerAnyType(userId);
+
+  if (!account) {
+    throw new AppError(
+      '해당 사용자는 승인 완료된 판매자로 등록되어 있지 않습니다.',
+      404,
+      'SellerNotFound',
+    );
+  }
+
+  const { deactivated_prompt_count } =
+    await AdminSellerRepository.cancelSellerTransaction(userId);
+
+  return { user_id: userId, deactivated_prompt_count };
 };

--- a/swagger.json
+++ b/swagger.json
@@ -6726,6 +6726,78 @@
         }
       }
     },
+    "/api/admin/sellers/{userId}": {
+      "delete": {
+        "summary": "판매자 등록 취소",
+        "description": "관리자가 승인 완료(`APPROVED`) 상태의 판매자(개인/사업자 공통) 등록을 취소합니다.\n다음 작업이 트랜잭션으로 함께 수행됩니다.\n\n- 사용자의 활성 프롬프트 일괄 비활성화 (`Prompt.inactive_date = now()`)\n- `SettlementAccount` 레코드 하드 삭제\n\n기존 구매/정산 이력은 영향받지 않습니다.\n",
+        "tags": [
+          "AdminSeller"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "사용자 ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "취소 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "판매자 등록을 취소했습니다."
+                    },
+                    "statusCode": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "user_id": {
+                          "type": "integer",
+                          "example": 12
+                        },
+                        "deactivated_prompt_count": {
+                          "type": "integer",
+                          "example": 5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "유효하지 않은 사용자 ID"
+          },
+          "401": {
+            "description": "인증 실패"
+          },
+          "403": {
+            "description": "권한 없음"
+          },
+          "404": {
+            "description": "승인 완료된 판매자가 아님"
+          }
+        }
+      }
+    },
     "/api/settlements/accounts": {
       "get": {
         "summary": "등록된 정산 계좌 정보 조회",


### PR DESCRIPTION
## 📌 기능 설명
관리자가 등록된 판매자(개인/사업자)의 등록을 취소(해제)하는 API를 구현합니다. 취소 시 해당 사용자는 일반 회원으로 전환됩니다.
관련 이슈: #454

## 📌 구현 내용

### 추가된 엔드포인트

| 메서드 | 경로 | 동작 |
|--------|------|------|
| `DELETE` | `/api/admin/sellers/:userId` | 판매자 등록 취소 (개인/사업자 공통) |

`authenticateJwt` + `isAdmin` 미들웨어 적용.

### 트랜잭션 처리
`prisma.$transaction([])`으로 다음 두 작업을 묶음:
1. **활성 프롬프트 일괄 비활성화**: `Prompt.inactive_date=now()` (이미 비활성화된 프롬프트는 제외)
2. **SettlementAccount 하드 삭제**: `delete where user_id=:userId`

### 영향받지 않는 데이터
- 기존 구매(`Purchase`) 기록
- 기존 정산(`Settlement`) 내역
- 이미 다운로드된 프롬프트의 다운로드 권한

### 응답
```json
{
  "message": "판매자 등록을 취소했습니다.",
  "data": {
    "user_id": 12,
    "deactivated_prompt_count": 5
  },
  "statusCode": 200
}
```

### 설계 결정
- **하드 삭제 (SettlementAccount)**: 1:1 관계 + 기존 코드의 `deleteAccountByUserId` 패턴과 일치. 재등록 흐름 단순화
- **소프트 비활성화 (Prompt)**: 신규 구매는 차단하되 기존 구매자의 다운로드 권한은 보장
- **미정산 매출 미처리**: 정산 도메인은 별도 관리. 관리자가 정산 완료 후 취소 권장
- **상태 제한**: `APPROVED` 상태만 취소 가능 (`PENDING`은 `/pending/:userId` 반려, `REJECTED`는 이미 비활성)
- **알림 없음**: #451과 일관된 정책

### 변경 파일
- `src/settlements/dtos/admin-seller.dto.ts` — `SellerCancellationResult` 추가
- `src/settlements/repositories/admin-seller.repository.ts` — `findApprovedSellerAnyType`, `cancelSellerTransaction`
- `src/settlements/services/admin-seller.service.ts` — `cancelSeller` (검증 + 트랜잭션 위임)
- `src/settlements/controllers/admin-seller.controller.ts` — `cancelSellerHandler`
- `src/settlements/routes/admin-seller.route.ts` — `DELETE /:userId` 라우트 + Swagger
- `swagger.json` — 빌드 시 자동 재생성

## 📌 구현 결과
- `pnpm build` 통과 (tsc 0 errors)
- Swagger `/api-docs` → `AdminSeller` 태그에 신규 API 표시

## 📌 논의하고 싶은 점
- 미정산 매출이 있는 상태에서의 취소를 차단할 필요가 있을지 (현재는 차단하지 않음)
- 프롬프트 비활성화 후 재등록 시 다시 활성화할지 정책 검토 필요
- 취소 사유 입력 필드 운영상 필요 여부 (현재는 미수집)