### PR TITLE
feat: 관리자 회원 가입 현황 통계 API 구현

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import messageRouter from "./messages/routes/message.route";
 import adminPromptRouter from "./prompts/routes/admin-prompt.route";
 import adminMemberRouter from "./members/routes/admin-member.route";
 import adminSellerRouter from "./settlements/routes/admin-seller.route";
+import adminStatsRouter from "./stats/routes/admin-stats.route";
 import signupRouter from "./signup/routes/signup.route"
 import signinRouter from "./signin/routes/signin.route";
 import passwordRouter from "./password/routes/password.route";
@@ -155,6 +156,7 @@ app.use("/api/prompts", promptLikeRouter);
 // admin
 app.use("/api/admin/prompts", adminPromptRouter);
 app.use("/api/admin/sellers", adminSellerRouter);
+app.use("/api/admin/stats", adminStatsRouter);
 app.use("/api/admin", adminMemberRouter);
 
 // 팁 라우터

--- a/src/stats/controllers/admin-stats.controller.ts
+++ b/src/stats/controllers/admin-stats.controller.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from 'express';
+import { getMemberStats } from '../services/admin-stats.service';
+
+export const getMemberStatsHandler = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const result = await getMemberStats();
+    return res.success(result, '회원 가입 현황을 조회했습니다.');
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/src/stats/dtos/admin-stats.dto.ts
+++ b/src/stats/dtos/admin-stats.dto.ts
@@ -1,0 +1,11 @@
+export type SignupChannel = 'email' | 'google' | 'kakao' | 'naver';
+
+export interface SignupChannelStats {
+  count: number;
+  ratio: number;
+}
+
+export interface MemberStatsResponse {
+  total_members: number;
+  by_signup_channel: Record<SignupChannel, SignupChannelStats>;
+}

--- a/src/stats/repositories/admin-stats.repository.ts
+++ b/src/stats/repositories/admin-stats.repository.ts
@@ -1,0 +1,11 @@
+import prisma from '../../config/prisma';
+
+export const AdminStatsRepository = {
+  countMembersBySocialType: async () => {
+    return prisma.user.groupBy({
+      by: ['social_type'],
+      where: { userstatus: { not: 'deleted' } },
+      _count: { _all: true },
+    });
+  },
+};

--- a/src/stats/routes/admin-stats.route.ts
+++ b/src/stats/routes/admin-stats.route.ts
@@ -1,0 +1,78 @@
+import { Router } from 'express';
+import { authenticateJwt } from '../../config/passport';
+import { isAdmin } from '../../middlewares/isAdmin';
+import { getMemberStatsHandler } from '../controllers/admin-stats.controller';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: AdminStats
+ *     description: 관리자 - 대시보드 통계 API
+ */
+
+/**
+ * @swagger
+ * /api/admin/stats/members:
+ *   get:
+ *     summary: 회원 가입 현황 조회
+ *     description: |
+ *       관리자 대시보드의 사용자 통계 영역에서 사용할 회원 가입 현황을 조회합니다.
+ *
+ *       - 총 회원수: 탈퇴(`deleted`) 상태를 제외한 전체 회원수
+ *       - 가입 경로별 비율: 자체 이메일(`NONE`) / 구글 / 카카오 / 네이버
+ *
+ *       `ratio`는 0~1 사이 값(소수점 4자리)으로 반환됩니다.
+ *     tags: [AdminStats]
+ *     security:
+ *       - jwt: []
+ *     responses:
+ *       200:
+ *         description: 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 회원 가입 현황을 조회했습니다.
+ *                 statusCode:
+ *                   type: integer
+ *                   example: 200
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     total_members: { type: integer, example: 1234 }
+ *                     by_signup_channel:
+ *                       type: object
+ *                       properties:
+ *                         email:
+ *                           type: object
+ *                           properties:
+ *                             count: { type: integer, example: 700 }
+ *                             ratio: { type: number, example: 0.5673 }
+ *                         google:
+ *                           type: object
+ *                           properties:
+ *                             count: { type: integer, example: 250 }
+ *                             ratio: { type: number, example: 0.2026 }
+ *                         kakao:
+ *                           type: object
+ *                           properties:
+ *                             count: { type: integer, example: 200 }
+ *                             ratio: { type: number, example: 0.1621 }
+ *                         naver:
+ *                           type: object
+ *                           properties:
+ *                             count: { type: integer, example: 84 }
+ *                             ratio: { type: number, example: 0.0681 }
+ *       401:
+ *         description: 인증 실패
+ *       403:
+ *         description: 권한 없음
+ */
+router.get('/members', authenticateJwt, isAdmin, getMemberStatsHandler);
+
+export default router;

--- a/src/stats/services/admin-stats.service.ts
+++ b/src/stats/services/admin-stats.service.ts
@@ -1,0 +1,47 @@
+import { AdminStatsRepository } from '../repositories/admin-stats.repository';
+import {
+  MemberStatsResponse,
+  SignupChannel,
+  SignupChannelStats,
+} from '../dtos/admin-stats.dto';
+
+const SOCIAL_TYPE_TO_CHANNEL: Record<string, SignupChannel> = {
+  NONE: 'email',
+  GOOGLE: 'google',
+  KAKAO: 'kakao',
+  NAVER: 'naver',
+};
+
+const emptyChannelStats = (): Record<SignupChannel, SignupChannelStats> => ({
+  email: { count: 0, ratio: 0 },
+  google: { count: 0, ratio: 0 },
+  kakao: { count: 0, ratio: 0 },
+  naver: { count: 0, ratio: 0 },
+});
+
+const round4 = (value: number): number => Math.round(value * 10000) / 10000;
+
+export const getMemberStats = async (): Promise<MemberStatsResponse> => {
+  const grouped = await AdminStatsRepository.countMembersBySocialType();
+
+  const byChannel = emptyChannelStats();
+  let total = 0;
+
+  for (const row of grouped) {
+    const channel = SOCIAL_TYPE_TO_CHANNEL[row.social_type];
+    if (!channel) continue;
+    byChannel[channel].count = row._count._all;
+    total += row._count._all;
+  }
+
+  if (total > 0) {
+    (Object.keys(byChannel) as SignupChannel[]).forEach((channel) => {
+      byChannel[channel].ratio = round4(byChannel[channel].count / total);
+    });
+  }
+
+  return {
+    total_members: total,
+    by_signup_channel: byChannel,
+  };
+};

--- a/swagger.json
+++ b/swagger.json
@@ -7328,6 +7328,114 @@
         }
       }
     },
+    "/api/admin/stats/members": {
+      "get": {
+        "summary": "회원 가입 현황 조회",
+        "description": "관리자 대시보드의 사용자 통계 영역에서 사용할 회원 가입 현황을 조회합니다.\n\n- 총 회원수: 탈퇴(`deleted`) 상태를 제외한 전체 회원수\n- 가입 경로별 비율: 자체 이메일(`NONE`) / 구글 / 카카오 / 네이버\n\n`ratio`는 0~1 사이 값(소수점 4자리)으로 반환됩니다.\n",
+        "tags": [
+          "AdminStats"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "회원 가입 현황을 조회했습니다."
+                    },
+                    "statusCode": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "total_members": {
+                          "type": "integer",
+                          "example": 1234
+                        },
+                        "by_signup_channel": {
+                          "type": "object",
+                          "properties": {
+                            "email": {
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "example": 700
+                                },
+                                "ratio": {
+                                  "type": "number",
+                                  "example": 0.5673
+                                }
+                              }
+                            },
+                            "google": {
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "example": 250
+                                },
+                                "ratio": {
+                                  "type": "number",
+                                  "example": 0.2026
+                                }
+                              }
+                            },
+                            "kakao": {
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "example": 200
+                                },
+                                "ratio": {
+                                  "type": "number",
+                                  "example": 0.1621
+                                }
+                              }
+                            },
+                            "naver": {
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "example": 84
+                                },
+                                "ratio": {
+                                  "type": "number",
+                                  "example": 0.0681
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패"
+          },
+          "403": {
+            "description": "권한 없음"
+          }
+        }
+      }
+    },
     "/api/tips": {
       "get": {
         "summary": "팁 목록 조회",
@@ -7678,6 +7786,10 @@
     {
       "name": "Settlement",
       "description": "정산 관리 관련 API"
+    },
+    {
+      "name": "AdminStats",
+      "description": "관리자 - 대시보드 통계 API"
     },
     {
       "name": "Tip",


### PR DESCRIPTION
## 📌 기능 설명
관리자 대시보드 상단의 사용자 통계 영역에서 사용할 회원 가입 현황 API를 구현합니다.
관련 이슈: #455

> 방문자 지표와 활성 사용자 지표는 추적 인프라가 부재하여 별도 이슈로 분리되었습니다.
> - #461 — 방문자 추적 인프라 + 통계 API
> - #462 — 활성 사용자 추적 인프라 + 통계 API

## 📌 구현 내용

### 추가된 엔드포인트

| 메서드 | 경로 | 동작 |
|--------|------|------|
| `GET` | `/api/admin/stats/members` | 회원 가입 현황 조회 |

`authenticateJwt` + `isAdmin` 미들웨어 적용.

### 응답
```json
{
  "message": "회원 가입 현황을 조회했습니다.",
  "statusCode": 200,
  "data": {
    "total_members": 1234,
    "by_signup_channel": {
      "email":  { "count": 700, "ratio": 0.5673 },
      "google": { "count": 250, "ratio": 0.2026 },
      "kakao":  { "count": 200, "ratio": 0.1621 },
      "naver":  { "count":  84, "ratio": 0.0681 }
    }
  }
}
```

### 설계 결정
- **신규 모듈 `src/stats/`**: `/api/admin/stats/*` 경로에 맞춰 별도 도메인으로 구성. #461, #462가 같은 모듈에 합류 가능
- **탈퇴 회원 제외**: `userstatus != 'deleted'`. `banned` 상태는 포함 (운영 정책상 가입은 유지된 상태로 간주)
- **`social_type` 매핑**: `NONE → email`, `GOOGLE → google`, `KAKAO → kakao`, `NAVER → naver`. 알 수 없는 값은 응답에서 제외
- **단일 `groupBy` 쿼리**: 4개 채널 + 총계를 한 번에 산출하여 DB 라운드트립 최소화
- **`ratio` 형식**: 0~1 범위, 소수 4자리 (`0.5673`)

### 변경 파일
- `src/stats/dtos/admin-stats.dto.ts` — `MemberStatsResponse`, `SignupChannel`
- `src/stats/repositories/admin-stats.repository.ts` — `countMembersBySocialType` (Prisma `groupBy`)
- `src/stats/services/admin-stats.service.ts` — `getMemberStats` (집계 + 비율 계산)
- `src/stats/controllers/admin-stats.controller.ts` — `getMemberStatsHandler`
- `src/stats/routes/admin-stats.route.ts` — `/members` 라우트 + Swagger
- `src/index.ts` — `/api/admin/stats`에 라우터 마운트
- `swagger.json` — 빌드 시 자동 재생성

## 📌 구현 결과
- `pnpm build` 통과 (tsc 0 errors)
- Swagger `/api-docs` → `AdminStats` 태그에 신규 API 표시

## 📌 논의하고 싶은 점
- `banned` 사용자를 통계에 포함시키는 게 맞을지 정책 확인 필요 (현재 포함)
- 향후 회원수가 크게 늘어나면 `count`/`groupBy` 부하 검토 (수십만 단위 전까지는 무관)