### PR TITLE
feat: 관리자 신규/매출 상위 프롬프트 통계 API 구현

### DIFF
--- a/src/stats/controllers/admin-prompt-stats.controller.ts
+++ b/src/stats/controllers/admin-prompt-stats.controller.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from 'express';
+import {
+  getNewPromptStats,
+  getTopSalesPrompts,
+} from '../services/admin-prompt-stats.service';
+
+export const getNewPromptStatsHandler = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const result = await getNewPromptStats();
+    return res.success(result, '신규 프롬프트 통계를 조회했습니다.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getTopSalesPromptsHandler = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const result = await getTopSalesPrompts();
+    return res.success(result, '매출 상위 프롬프트를 조회했습니다.');
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/src/stats/dtos/admin-prompt-stats.dto.ts
+++ b/src/stats/dtos/admin-prompt-stats.dto.ts
@@ -1,0 +1,22 @@
+export interface DailyUploadBucket {
+  date: string;
+  count: number;
+}
+
+export interface NewPromptStatsResponse {
+  daily_count: number;
+  weekly_count: number;
+  daily_uploads: DailyUploadBucket[];
+}
+
+export interface TopSalesPromptItem {
+  rank: number;
+  prompt_id: number;
+  title: string | null;
+  total_sales: number;
+}
+
+export interface TopSalesPromptsResponse {
+  period_days: number;
+  items: TopSalesPromptItem[];
+}

--- a/src/stats/repositories/admin-prompt-stats.repository.ts
+++ b/src/stats/repositories/admin-prompt-stats.repository.ts
@@ -1,0 +1,28 @@
+import prisma from '../../config/prisma';
+
+export const AdminPromptStatsRepository = {
+  findActivePromptCreatedAtsSince: async (since: Date) => {
+    return prisma.prompt.findMany({
+      where: { created_at: { gte: since }, inactive_date: null },
+      select: { created_at: true },
+    });
+  },
+
+  groupPaidPurchaseAmountSince: async (since: Date, take: number) => {
+    return prisma.purchase.groupBy({
+      by: ['prompt_id'],
+      where: { created_at: { gte: since }, is_free: false },
+      _sum: { amount: true },
+      orderBy: { _sum: { amount: 'desc' } },
+      take,
+    });
+  },
+
+  findPromptTitlesByIds: async (promptIds: number[]) => {
+    if (promptIds.length === 0) return [];
+    return prisma.prompt.findMany({
+      where: { prompt_id: { in: promptIds } },
+      select: { prompt_id: true, title: true },
+    });
+  },
+};

--- a/src/stats/routes/admin-stats.route.ts
+++ b/src/stats/routes/admin-stats.route.ts
@@ -2,6 +2,10 @@ import { Router } from 'express';
 import { authenticateJwt } from '../../config/passport';
 import { isAdmin } from '../../middlewares/isAdmin';
 import { getMemberStatsHandler } from '../controllers/admin-stats.controller';
+import {
+  getNewPromptStatsHandler,
+  getTopSalesPromptsHandler,
+} from '../controllers/admin-prompt-stats.controller';
 
 const router = Router();
 
@@ -74,5 +78,100 @@ const router = Router();
  *         description: 권한 없음
  */
 router.get('/members', authenticateJwt, isAdmin, getMemberStatsHandler);
+
+/**
+ * @swagger
+ * /api/admin/stats/prompts/new:
+ *   get:
+ *     summary: 신규 프롬프트 통계 조회
+ *     description: |
+ *       관리자 대시보드의 신규 프롬프트 영역에서 사용하는 통계 API.
+ *
+ *       - `daily_count`: 최근 24시간(롤링 윈도우) 동안 업로드된 활성 프롬프트 수
+ *       - `weekly_count`: 최근 7일(KST 캘린더 기준) 업로드 합계
+ *       - `daily_uploads`: 최근 7일치 일자별 업로드 수 (KST 기준 `YYYY-MM-DD`, 막대 그래프용)
+ *
+ *       비활성(`inactive_date IS NOT NULL`) 프롬프트는 모두 제외됩니다.
+ *     tags: [AdminStats]
+ *     security:
+ *       - jwt: []
+ *     responses:
+ *       200:
+ *         description: 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message: { type: string, example: 신규 프롬프트 통계를 조회했습니다. }
+ *                 statusCode: { type: integer, example: 200 }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     daily_count: { type: integer, example: 12 }
+ *                     weekly_count: { type: integer, example: 86 }
+ *                     daily_uploads:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           date: { type: string, example: "2026-05-11" }
+ *                           count: { type: integer, example: 14 }
+ *       401:
+ *         description: 인증 실패
+ *       403:
+ *         description: 권한 없음
+ */
+router.get('/prompts/new', authenticateJwt, isAdmin, getNewPromptStatsHandler);
+
+/**
+ * @swagger
+ * /api/admin/stats/prompts/top-sales:
+ *   get:
+ *     summary: 매출 상위 프롬프트 Top 5 조회
+ *     description: |
+ *       최근 30일간 매출액 기준 상위 5개 프롬프트를 조회합니다.
+ *
+ *       - 기준: `Purchase.amount` 합계 (`is_free=false`만 합산)
+ *       - 기간: 최근 30일(롤링 윈도우)
+ *       - 정렬: `total_sales DESC`, 동률 시 Prisma 기본 순서
+ *       - 프롬프트가 삭제·비활성화되어도 매출 집계에는 포함되며, 제목이 없을 경우 `title: null`로 반환됩니다.
+ *     tags: [AdminStats]
+ *     security:
+ *       - jwt: []
+ *     responses:
+ *       200:
+ *         description: 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message: { type: string, example: 매출 상위 프롬프트를 조회했습니다. }
+ *                 statusCode: { type: integer, example: 200 }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     period_days: { type: integer, example: 30 }
+ *                     items:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           rank: { type: integer, example: 1 }
+ *                           prompt_id: { type: integer, example: 42 }
+ *                           title: { type: string, nullable: true, example: "ChatGPT 마케팅 카피 30종" }
+ *                           total_sales: { type: integer, example: 825000 }
+ *       401:
+ *         description: 인증 실패
+ *       403:
+ *         description: 권한 없음
+ */
+router.get(
+  '/prompts/top-sales',
+  authenticateJwt,
+  isAdmin,
+  getTopSalesPromptsHandler,
+);
 
 export default router;

--- a/src/stats/services/admin-prompt-stats.service.ts
+++ b/src/stats/services/admin-prompt-stats.service.ts
@@ -1,0 +1,94 @@
+import { AdminPromptStatsRepository } from '../repositories/admin-prompt-stats.repository';
+import {
+  DailyUploadBucket,
+  NewPromptStatsResponse,
+  TopSalesPromptsResponse,
+} from '../dtos/admin-prompt-stats.dto';
+
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const TOP_SALES_PERIOD_DAYS = 30;
+const TOP_SALES_LIMIT = 5;
+
+const toKstDateString = (date: Date): string => {
+  return new Date(date.getTime() + KST_OFFSET_MS).toISOString().slice(0, 10);
+};
+
+const startOfKstDay = (kstDateString: string): Date => {
+  return new Date(`${kstDateString}T00:00:00+09:00`);
+};
+
+const buildLast7KstDates = (now: Date): string[] => {
+  const todayKst = toKstDateString(now);
+  const [year, month, day] = todayKst.split('-').map(Number);
+  const dates: string[] = [];
+  for (let offset = 6; offset >= 0; offset--) {
+    const d = new Date(Date.UTC(year, month - 1, day - offset));
+    dates.push(d.toISOString().slice(0, 10));
+  }
+  return dates;
+};
+
+export const getNewPromptStats = async (): Promise<NewPromptStatsResponse> => {
+  const now = new Date();
+  const dates = buildLast7KstDates(now);
+  const windowStart = startOfKstDay(dates[0]);
+
+  const prompts =
+    await AdminPromptStatsRepository.findActivePromptCreatedAtsSince(
+      windowStart,
+    );
+
+  const buckets: Record<string, number> = Object.fromEntries(
+    dates.map((d) => [d, 0]),
+  );
+  for (const p of prompts) {
+    const key = toKstDateString(p.created_at);
+    if (key in buckets) {
+      buckets[key]++;
+    }
+  }
+
+  const daily_uploads: DailyUploadBucket[] = dates.map((date) => ({
+    date,
+    count: buckets[date],
+  }));
+
+  const weekly_count = daily_uploads.reduce((sum, b) => sum + b.count, 0);
+
+  const last24hStart = new Date(now.getTime() - DAY_MS);
+  const daily_count = prompts.filter(
+    (p) => p.created_at.getTime() >= last24hStart.getTime(),
+  ).length;
+
+  return {
+    daily_count,
+    weekly_count,
+    daily_uploads,
+  };
+};
+
+export const getTopSalesPrompts = async (): Promise<TopSalesPromptsResponse> => {
+  const since = new Date(Date.now() - TOP_SALES_PERIOD_DAYS * DAY_MS);
+
+  const grouped =
+    await AdminPromptStatsRepository.groupPaidPurchaseAmountSince(
+      since,
+      TOP_SALES_LIMIT,
+    );
+
+  const titles = await AdminPromptStatsRepository.findPromptTitlesByIds(
+    grouped.map((g) => g.prompt_id),
+  );
+  const titleMap = new Map(titles.map((t) => [t.prompt_id, t.title]));
+
+  return {
+    period_days: TOP_SALES_PERIOD_DAYS,
+    items: grouped.map((g, idx) => ({
+      rank: idx + 1,
+      prompt_id: g.prompt_id,
+      title: titleMap.get(g.prompt_id) ?? null,
+      total_sales: g._sum.amount ?? 0,
+    })),
+  };
+};

--- a/swagger.json
+++ b/swagger.json
@@ -7436,6 +7436,153 @@
         }
       }
     },
+    "/api/admin/stats/prompts/new": {
+      "get": {
+        "summary": "신규 프롬프트 통계 조회",
+        "description": "관리자 대시보드의 신규 프롬프트 영역에서 사용하는 통계 API.\n\n- `daily_count`: 최근 24시간(롤링 윈도우) 동안 업로드된 활성 프롬프트 수\n- `weekly_count`: 최근 7일(KST 캘린더 기준) 업로드 합계\n- `daily_uploads`: 최근 7일치 일자별 업로드 수 (KST 기준 `YYYY-MM-DD`, 막대 그래프용)\n\n비활성(`inactive_date IS NOT NULL`) 프롬프트는 모두 제외됩니다.\n",
+        "tags": [
+          "AdminStats"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "신규 프롬프트 통계를 조회했습니다."
+                    },
+                    "statusCode": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "daily_count": {
+                          "type": "integer",
+                          "example": 12
+                        },
+                        "weekly_count": {
+                          "type": "integer",
+                          "example": 86
+                        },
+                        "daily_uploads": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "date": {
+                                "type": "string",
+                                "example": "2026-05-11"
+                              },
+                              "count": {
+                                "type": "integer",
+                                "example": 14
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패"
+          },
+          "403": {
+            "description": "권한 없음"
+          }
+        }
+      }
+    },
+    "/api/admin/stats/prompts/top-sales": {
+      "get": {
+        "summary": "매출 상위 프롬프트 Top 5 조회",
+        "description": "최근 30일간 매출액 기준 상위 5개 프롬프트를 조회합니다.\n\n- 기준: `Purchase.amount` 합계 (`is_free=false`만 합산)\n- 기간: 최근 30일(롤링 윈도우)\n- 정렬: `total_sales DESC`, 동률 시 Prisma 기본 순서\n- 프롬프트가 삭제·비활성화되어도 매출 집계에는 포함되며, 제목이 없을 경우 `title: null`로 반환됩니다.\n",
+        "tags": [
+          "AdminStats"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "매출 상위 프롬프트를 조회했습니다."
+                    },
+                    "statusCode": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "period_days": {
+                          "type": "integer",
+                          "example": 30
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "rank": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "prompt_id": {
+                                "type": "integer",
+                                "example": 42
+                              },
+                              "title": {
+                                "type": "string",
+                                "nullable": true,
+                                "example": "ChatGPT 마케팅 카피 30종"
+                              },
+                              "total_sales": {
+                                "type": "integer",
+                                "example": 825000
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패"
+          },
+          "403": {
+            "description": "권한 없음"
+          }
+        }
+      }
+    },
     "/api/tips": {
       "get": {
         "summary": "팁 목록 조회",


### PR DESCRIPTION
## 📌 기능 설명
관리자 대시보드의 프롬프트 섹션(신규 / 매출 상위)에서 사용할 통계 API를 구현합니다.
관련 이슈: #456

> 인기 프롬프트(최근 7일 조회+다운수 기준)는 `Prompt.views`/`Prompt.downloads`가 누적 카운터라 시간 윈도우 산출이 불가능합니다. 일일 스냅샷 인프라가 필요해 별도 이슈로 분리되었습니다.
> - #464 — 프롬프트 조회수/다운수 일일 스냅샷 + 인기 프롬프트 API

## 📌 구현 내용

### 추가된 엔드포인트 (모두 `authenticateJwt` + `isAdmin` 적용)

| 메서드 | 경로 | 동작 |
|--------|------|------|
| `GET` | `/api/admin/stats/prompts/new` | 신규 프롬프트 통계 (일일·주간·날짜별) |
| `GET` | `/api/admin/stats/prompts/top-sales` | 매출 상위 Top 5 |

### 신규 프롬프트 통계 응답
```json
{
  "data": {
    "daily_count": 12,
    "weekly_count": 86,
    "daily_uploads": [
      { "date": "2026-05-11", "count": 14 },
      { "date": "2026-05-12", "count": 11 },
      "...(총 7개)"
    ]
  }
}
```

### 매출 상위 응답
```json
{
  "data": {
    "period_days": 30,
    "items": [
      { "rank": 1, "prompt_id": 42, "title": "...", "total_sales": 825000 }
    ]
  }
}
```

### 설계 결정
- **시간 기준 처리**
  - `daily_count`: 최근 24시간(롤링 윈도우)
  - `weekly_count`: 최근 7일 KST 캘린더 합계 (= `daily_uploads` 합)
  - `daily_uploads`: KST 기준 7일치 (오늘 포함)
- **삭제 정책 (신규 통계)**: `inactive_date IS NOT NULL` 프롬프트 제외
- **매출 집계**
  - `Purchase.is_free=false`만 합산 (무료 다운로드 제외)
  - 기간: 최근 30일 롤링
  - 비활성/삭제 프롬프트도 매출 집계에 포함 (과거 매출 기록 보존), 제목 없으면 `title: null`
- **Top 5 정렬**: Prisma `groupBy ... orderBy: { _sum: { amount: 'desc' } } take: 5`

### 변경 파일
- `src/stats/dtos/admin-prompt-stats.dto.ts` — 응답 타입
- `src/stats/repositories/admin-prompt-stats.repository.ts` — `findActivePromptCreatedAtsSince`, `groupPaidPurchaseAmountSince`, `findPromptTitlesByIds`
- `src/stats/services/admin-prompt-stats.service.ts` — KST 날짜 변환, 7일 버킷 생성, Top 5 매핑
- `src/stats/controllers/admin-prompt-stats.controller.ts` — 핸들러 2개
- `src/stats/routes/admin-stats.route.ts` — 2개 라우트 + Swagger
- `swagger.json` — 빌드 시 자동 재생성

## 📌 구현 결과
- `pnpm build` 통과 (tsc 0 errors)
- Swagger `/api-docs` → `AdminStats` 태그에 신규 2개 API 표시

## 📌 논의하고 싶은 점
- 매출 집계 시 환불/취소된 구매 처리: 현재 `Purchase` 기준이며 환불 상태를 별도로 필터링하지 않음. `Payment.status`나 환불 모델이 추가되면 반영 필요
- 비활성/삭제 프롬프트의 매출을 Top 5에서 보여줄지 정책 확인 필요 (현재 포함, 제목 없을 시 `null`)
- `period_days` 응답에 포함 — 향후 30일/14일/90일 등 옵션화 검토 가능