### PR TITLE
feat: 활성 사용자 추적 인프라 및 통계 API 구현

### DIFF
--- a/prisma/migrations/20260517005759_add_user_last_active_at/migration.sql
+++ b/prisma/migrations/20260517005759_add_user_last_active_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `User` ADD COLUMN `last_active_at` DATETIME(3) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   status               Boolean
   userstatus            userStatus                @default(active)
   inactive_date        DateTime?
+  last_active_at       DateTime?
   created_at           DateTime                   @default(now())
   updated_at           DateTime                   @updatedAt
   role                 Role                       @default(USER)

--- a/src/config/passport.ts
+++ b/src/config/passport.ts
@@ -12,6 +12,7 @@ import { configureGoogleStrategy } from "./social/google";
 import { configureNaverStrategy } from "./social/naver";
 import { configureKakaoStrategy } from "./social/kakao";
 import { isActive } from "../utils/status";
+import { recordUserActivity } from "../utils/user-activity";
 import prisma from "./prisma";
 
 // JWT Strategy 설정
@@ -39,6 +40,8 @@ passport.use(
           (error as any).message = "로그인이 필요합니다.";
           return done(error, false);
         }
+
+        void recordUserActivity(user.user_id);
 
         return done(null, user);
       } catch (err) {

--- a/src/stats/controllers/admin-stats.controller.ts
+++ b/src/stats/controllers/admin-stats.controller.ts
@@ -1,5 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
-import { getMemberStats } from '../services/admin-stats.service';
+import {
+  getActiveUserStats,
+  getMemberStats,
+} from '../services/admin-stats.service';
 
 export const getMemberStatsHandler = async (
   _req: Request,
@@ -9,6 +12,19 @@ export const getMemberStatsHandler = async (
   try {
     const result = await getMemberStats();
     return res.success(result, '회원 가입 현황을 조회했습니다.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getActiveUserStatsHandler = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const result = await getActiveUserStats();
+    return res.success(result, '활성 사용자 통계를 조회했습니다.');
   } catch (error) {
     return next(error);
   }

--- a/src/stats/dtos/admin-stats.dto.ts
+++ b/src/stats/dtos/admin-stats.dto.ts
@@ -9,3 +9,10 @@ export interface MemberStatsResponse {
   total_members: number;
   by_signup_channel: Record<SignupChannel, SignupChannelStats>;
 }
+
+export interface ActiveUserStatsResponse {
+  window_days: number;
+  current_count: number;
+  previous_count: number;
+  change_rate: number | null;
+}

--- a/src/stats/repositories/admin-stats.repository.ts
+++ b/src/stats/repositories/admin-stats.repository.ts
@@ -8,4 +8,13 @@ export const AdminStatsRepository = {
       _count: { _all: true },
     });
   },
+
+  countActiveUsersInRange: async (start: Date, end: Date) => {
+    return prisma.user.count({
+      where: {
+        userstatus: { not: 'deleted' },
+        last_active_at: { gte: start, lt: end },
+      },
+    });
+  },
 };

--- a/src/stats/routes/admin-stats.route.ts
+++ b/src/stats/routes/admin-stats.route.ts
@@ -1,7 +1,10 @@
 import { Router } from 'express';
 import { authenticateJwt } from '../../config/passport';
 import { isAdmin } from '../../middlewares/isAdmin';
-import { getMemberStatsHandler } from '../controllers/admin-stats.controller';
+import {
+  getActiveUserStatsHandler,
+  getMemberStatsHandler,
+} from '../controllers/admin-stats.controller';
 import {
   getNewPromptStatsHandler,
   getTopSalesPromptsHandler,
@@ -78,6 +81,55 @@ const router = Router();
  *         description: 권한 없음
  */
 router.get('/members', authenticateJwt, isAdmin, getMemberStatsHandler);
+
+/**
+ * @swagger
+ * /api/admin/stats/active-users:
+ *   get:
+ *     summary: 활성 사용자 통계 조회
+ *     description: |
+ *       최근 30일 롤링 윈도우 기준 활성 사용자 수와 전 구간(그 이전 30일) 대비 증감율을 반환합니다.
+ *
+ *       - `current_count`: now - 30d ~ now 사이에 `last_active_at`이 기록된 사용자 수
+ *       - `previous_count`: now - 60d ~ now - 30d 사이의 활성 사용자 수
+ *       - `change_rate`: `(current - previous) / previous` (소수 4자리). 이전 구간이 0이면 `null`
+ *       - 탈퇴(`userstatus=deleted`) 사용자는 제외
+ *
+ *       활동 기록은 JWT 인증을 통과한 모든 요청에서 5분 throttle로 갱신됩니다.
+ *     tags: [AdminStats]
+ *     security:
+ *       - jwt: []
+ *     responses:
+ *       200:
+ *         description: 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message: { type: string, example: 활성 사용자 통계를 조회했습니다. }
+ *                 statusCode: { type: integer, example: 200 }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     window_days: { type: integer, example: 30 }
+ *                     current_count: { type: integer, example: 1234 }
+ *                     previous_count: { type: integer, example: 1100 }
+ *                     change_rate:
+ *                       type: number
+ *                       nullable: true
+ *                       example: 0.1218
+ *       401:
+ *         description: 인증 실패
+ *       403:
+ *         description: 권한 없음
+ */
+router.get(
+  '/active-users',
+  authenticateJwt,
+  isAdmin,
+  getActiveUserStatsHandler,
+);
 
 /**
  * @swagger

--- a/src/stats/services/admin-stats.service.ts
+++ b/src/stats/services/admin-stats.service.ts
@@ -1,5 +1,6 @@
 import { AdminStatsRepository } from '../repositories/admin-stats.repository';
 import {
+  ActiveUserStatsResponse,
   MemberStatsResponse,
   SignupChannel,
   SignupChannelStats,
@@ -43,5 +44,33 @@ export const getMemberStats = async (): Promise<MemberStatsResponse> => {
   return {
     total_members: total,
     by_signup_channel: byChannel,
+  };
+};
+
+const ACTIVE_WINDOW_DAYS = 30;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const getActiveUserStats = async (): Promise<ActiveUserStatsResponse> => {
+  const now = new Date();
+  const currentStart = new Date(now.getTime() - ACTIVE_WINDOW_DAYS * DAY_MS);
+  const previousStart = new Date(
+    currentStart.getTime() - ACTIVE_WINDOW_DAYS * DAY_MS,
+  );
+
+  const [current_count, previous_count] = await Promise.all([
+    AdminStatsRepository.countActiveUsersInRange(currentStart, now),
+    AdminStatsRepository.countActiveUsersInRange(previousStart, currentStart),
+  ]);
+
+  const change_rate =
+    previous_count === 0
+      ? null
+      : round4((current_count - previous_count) / previous_count);
+
+  return {
+    window_days: ACTIVE_WINDOW_DAYS,
+    current_count,
+    previous_count,
+    change_rate,
   };
 };

--- a/src/utils/user-activity.ts
+++ b/src/utils/user-activity.ts
@@ -1,0 +1,28 @@
+import redisClient from '../config/redis';
+import prisma from '../config/prisma';
+
+const THROTTLE_SECONDS = 300;
+
+export const recordUserActivity = async (userId: number): Promise<void> => {
+  try {
+    const key = `user_active:${userId}`;
+    const setResult = await redisClient.set(key, '1', {
+      NX: true,
+      EX: THROTTLE_SECONDS,
+    });
+
+    if (setResult !== 'OK') {
+      return;
+    }
+
+    await prisma.user.update({
+      where: { user_id: userId },
+      data: { last_active_at: new Date() },
+    });
+  } catch (error) {
+    console.error('[user-activity] failed to record activity', {
+      userId,
+      error,
+    });
+  }
+};

--- a/swagger.json
+++ b/swagger.json
@@ -7436,6 +7436,70 @@
         }
       }
     },
+    "/api/admin/stats/active-users": {
+      "get": {
+        "summary": "활성 사용자 통계 조회",
+        "description": "최근 30일 롤링 윈도우 기준 활성 사용자 수와 전 구간(그 이전 30일) 대비 증감율을 반환합니다.\n\n- `current_count`: now - 30d ~ now 사이에 `last_active_at`이 기록된 사용자 수\n- `previous_count`: now - 60d ~ now - 30d 사이의 활성 사용자 수\n- `change_rate`: `(current - previous) / previous` (소수 4자리). 이전 구간이 0이면 `null`\n- 탈퇴(`userstatus=deleted`) 사용자는 제외\n\n활동 기록은 JWT 인증을 통과한 모든 요청에서 5분 throttle로 갱신됩니다.\n",
+        "tags": [
+          "AdminStats"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "활성 사용자 통계를 조회했습니다."
+                    },
+                    "statusCode": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "window_days": {
+                          "type": "integer",
+                          "example": 30
+                        },
+                        "current_count": {
+                          "type": "integer",
+                          "example": 1234
+                        },
+                        "previous_count": {
+                          "type": "integer",
+                          "example": 1100
+                        },
+                        "change_rate": {
+                          "type": "number",
+                          "nullable": true,
+                          "example": 0.1218
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패"
+          },
+          "403": {
+            "description": "권한 없음"
+          }
+        }
+      }
+    },
     "/api/admin/stats/prompts/new": {
       "get": {
         "summary": "신규 프롬프트 통계 조회",


### PR DESCRIPTION
## 📌 기능 설명
관리자 대시보드의 **활성 사용자 지표**를 위한 추적 인프라와 통계 API를 구현합니다.
관련 이슈: #462

## 📌 구현 내용

### 1. 스키마 변경
- `User.last_active_at: DateTime?` 컬럼 추가
- 마이그레이션 파일: `prisma/migrations/20260517005759_add_user_last_active_at`

⚠️ **배포 전 마이그레이션 적용 필요**: `pnpm prisma migrate deploy`

### 2. 활동 기록 인프라
- `src/utils/user-activity.ts` — `recordUserActivity(userId)`
- **Redis throttle**: `SET user_active:{userId} 1 NX EX 300`
  - 5분 내 중복 호출 시 Redis가 자동으로 거부 → DB UPDATE skip
  - NX 옵션으로 원자적 lock 획득
- DB UPDATE는 키 획득 성공 시에만 수행
- 실패해도 silent fail (로깅만, 인증 흐름 방해 금지)
- `src/config/passport.ts` JWT verify 콜백 끝에서 `void recordUserActivity(...)` fire-and-forget

→ **JWT로 인증된 모든 API 요청에서 활동 기록**됨. 별도 라우트 변경 불필요.

### 3. 통계 API
| 메서드 | 경로 | 동작 |
|--------|------|------|
| `GET` | `/api/admin/stats/active-users` | 활성 사용자 통계 (롤링 30일) |

`authenticateJwt` + `isAdmin` 적용.

#### 응답
```json
{
  "data": {
    "window_days": 30,
    "current_count": 1234,
    "previous_count": 1100,
    "change_rate": 0.1218
  }
}
```

### 설계 결정
- **활성 사용자 정의**: 최근 30일 롤링 윈도우(MAU 표준)
- **활동 트리거**: `authenticateJwt` 통과한 모든 요청 (passport verify 콜백 hook)
- **저장 위치**: `User.last_active_at` 컬럼 (별도 이벤트 테이블 아님, 단순함 우선)
- **DB throttle**: Redis 5분 (`SET NX EX`)
- **증감율 기준**: 롤링 30일 vs 그 이전 30일 비교
- **`change_rate`가 `null`**: 이전 구간이 0일 때 (0 나누기 회피)
- **기존 사용자**: `last_active_at = NULL` → 통계에서 비활성으로 자동 처리

### 변경 파일
- `prisma/schema.prisma` — `last_active_at` 추가
- `prisma/migrations/20260517005759_add_user_last_active_at/migration.sql` — 신규
- `src/utils/user-activity.ts` — 신규 (활동 기록 + throttle)
- `src/config/passport.ts` — JWT verify 콜백에 활동 기록 hook
- `src/stats/dtos/admin-stats.dto.ts` — `ActiveUserStatsResponse` 추가
- `src/stats/repositories/admin-stats.repository.ts` — `countActiveUsersInRange`
- `src/stats/services/admin-stats.service.ts` — `getActiveUserStats`
- `src/stats/controllers/admin-stats.controller.ts` — 핸들러 추가
- `src/stats/routes/admin-stats.route.ts` — `/active-users` 라우트 + Swagger
- `swagger.json` — 빌드 시 자동 재생성

## 📌 구현 결과
- `pnpm build` 통과 (tsc 0 errors)
- Swagger `/api-docs` → `AdminStats` 태그에 신규 API 표시

## 📌 논의하고 싶은 점
- **마이그레이션 적용 타이밍**: 배포 파이프라인에서 `prisma migrate deploy`가 자동 실행되는지 확인 필요
- **Redis 다운 시**: `recordUserActivity`가 catch로 silent fail. 일정 시간 활동 기록이 누락될 수 있으나 인증은 영향 없음
- **throttle 윈도우(5분)** 조정 필요 여부 — 짧을수록 DB 부하↑, 길수록 정확도↓
- 추후 `last_active_at`에 인덱스 추가 검토 (수만 명 이상일 때)