### PR TITLE
feat: 방문자 추적 인프라 및 통계 API 구현

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import http from "http";
 import { Server } from "socket.io"
 import { responseHandler } from "./middlewares/responseHandler";
 import { errorHandler } from "./middlewares/errorHandler";
+import { visitorTracker } from "./middlewares/visitorTracker";
 import "reflect-metadata";
 import passport from "./config/passport";
 import swaggerUi from "swagger-ui-express";
@@ -101,6 +102,9 @@ app.use(
   swaggerUi.serve,
   swaggerUi.setup(swaggerJsdoc(swaggerOptions))
 );
+
+// 방문자 추적 미들웨어 (응답 종료 시 HyperLogLog에 visitor_id 누적)
+app.use(visitorTracker);
 
 // 3. 모든 라우터들
 

--- a/src/middlewares/visitorTracker.ts
+++ b/src/middlewares/visitorTracker.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction } from 'express';
+import {
+  computeVisitorId,
+  isBotUserAgent,
+  recordVisit,
+} from '../utils/visitor-tracking';
+
+const SKIP_PATH_PREFIXES = [
+  '/health',
+  '/api-docs',
+  '/uploads',
+  '/api/notifications/sse',
+];
+
+const SKIP_METHODS = new Set(['OPTIONS', 'HEAD']);
+
+export const visitorTracker = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  if (SKIP_METHODS.has(req.method)) return next();
+  if (SKIP_PATH_PREFIXES.some((prefix) => req.path.startsWith(prefix))) {
+    return next();
+  }
+  if (isBotUserAgent(req.headers['user-agent'])) return next();
+
+  res.on('finish', () => {
+    if (res.statusCode >= 400) return;
+    void recordVisit(computeVisitorId(req));
+  });
+
+  next();
+};

--- a/src/stats/controllers/admin-visitor-stats.controller.ts
+++ b/src/stats/controllers/admin-visitor-stats.controller.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+import { getVisitorStats } from '../services/admin-visitor-stats.service';
+import { VisitorStatsQueryDto } from '../dtos/admin-stats.dto';
+
+export const getVisitorStatsHandler = async (
+  req: Request<unknown, unknown, unknown, VisitorStatsQueryDto>,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const result = await getVisitorStats(req.query.month);
+    return res.success(result, '방문자 통계를 조회했습니다.');
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/src/stats/dtos/admin-stats.dto.ts
+++ b/src/stats/dtos/admin-stats.dto.ts
@@ -16,3 +16,23 @@ export interface ActiveUserStatsResponse {
   previous_count: number;
   change_rate: number | null;
 }
+
+export interface VisitorStatsQueryDto {
+  month?: string;
+}
+
+export interface VisitorDailyBucket {
+  date: string;
+  count: number;
+}
+
+export interface VisitorStatsResponse {
+  daily_count: number;
+  window_days: number;
+  current_count: number;
+  previous_count: number;
+  change_rate: number | null;
+  month: string | null;
+  month_total: number | null;
+  month_daily: VisitorDailyBucket[] | null;
+}

--- a/src/stats/repositories/admin-visitor-stats.repository.ts
+++ b/src/stats/repositories/admin-visitor-stats.repository.ts
@@ -1,0 +1,24 @@
+import redisClient from '../../config/redis';
+import { buildHllKey } from '../../utils/visitor-tracking';
+
+export const AdminVisitorStatsRepository = {
+  countUniqueOnDate: async (kstDate: string): Promise<number> => {
+    return Number(await redisClient.pfCount(buildHllKey(kstDate)));
+  },
+
+  countUniqueOverRange: async (kstDates: string[]): Promise<number> => {
+    if (kstDates.length === 0) return 0;
+    const keys = kstDates.map(buildHllKey);
+    return Number(await redisClient.pfCount(keys));
+  },
+
+  countUniquePerDay: async (
+    kstDates: string[],
+  ): Promise<{ date: string; count: number }[]> => {
+    if (kstDates.length === 0) return [];
+    const counts = await Promise.all(
+      kstDates.map((d) => redisClient.pfCount(buildHllKey(d))),
+    );
+    return kstDates.map((date, i) => ({ date, count: Number(counts[i]) }));
+  },
+};

--- a/src/stats/routes/admin-stats.route.ts
+++ b/src/stats/routes/admin-stats.route.ts
@@ -9,6 +9,7 @@ import {
   getNewPromptStatsHandler,
   getTopSalesPromptsHandler,
 } from '../controllers/admin-prompt-stats.controller';
+import { getVisitorStatsHandler } from '../controllers/admin-visitor-stats.controller';
 
 const router = Router();
 
@@ -130,6 +131,78 @@ router.get(
   isAdmin,
   getActiveUserStatsHandler,
 );
+
+/**
+ * @swagger
+ * /api/admin/stats/visitors:
+ *   get:
+ *     summary: 방문자 통계 조회
+ *     description: |
+ *       방문자 통계를 조회합니다. 모든 카운트는 KST(Asia/Seoul) 캘린더 기준이며 Redis HyperLogLog를 사용해 고유 방문자 수를 추정(오차 ~0.81%)합니다.
+ *
+ *       - `daily_count`: 오늘(KST) 고유 방문자 수
+ *       - `current_count`: 최근 30일 롤링 윈도우 고유 방문자 수 (합집합)
+ *       - `previous_count`: 그 이전 30일 (now-60d ~ now-30d) 고유 방문자 수
+ *       - `change_rate`: `(current - previous) / previous` (소수 4자리). 이전 구간 0이면 `null`
+ *       - `?month=YYYY-MM` 파라미터 제공 시 `month_total`(해당 월 고유 방문자 합) + `month_daily`(일별 분포) 함께 반환
+ *
+ *       활동 기록은 모든 비-봇 API 요청에서 KST 일별 HyperLogLog 키에 `PFADD`로 누적됩니다.
+ *     tags: [AdminStats]
+ *     security:
+ *       - jwt: []
+ *     parameters:
+ *       - in: query
+ *         name: month
+ *         schema:
+ *           type: string
+ *           pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
+ *           example: "2026-05"
+ *         description: 특정 월의 일별 분포 조회 (선택)
+ *     responses:
+ *       200:
+ *         description: 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message: { type: string, example: 방문자 통계를 조회했습니다. }
+ *                 statusCode: { type: integer, example: 200 }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     daily_count: { type: integer, example: 312 }
+ *                     window_days: { type: integer, example: 30 }
+ *                     current_count: { type: integer, example: 9450 }
+ *                     previous_count: { type: integer, example: 8200 }
+ *                     change_rate:
+ *                       type: number
+ *                       nullable: true
+ *                       example: 0.1524
+ *                     month:
+ *                       type: string
+ *                       nullable: true
+ *                       example: "2026-05"
+ *                     month_total:
+ *                       type: integer
+ *                       nullable: true
+ *                       example: 8970
+ *                     month_daily:
+ *                       type: array
+ *                       nullable: true
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           date: { type: string, example: "2026-05-01" }
+ *                           count: { type: integer, example: 287 }
+ *       400:
+ *         description: 잘못된 month 파라미터 형식
+ *       401:
+ *         description: 인증 실패
+ *       403:
+ *         description: 권한 없음
+ */
+router.get('/visitors', authenticateJwt, isAdmin, getVisitorStatsHandler);
 
 /**
  * @swagger

--- a/src/stats/services/admin-visitor-stats.service.ts
+++ b/src/stats/services/admin-visitor-stats.service.ts
@@ -1,0 +1,92 @@
+import { AdminVisitorStatsRepository } from '../repositories/admin-visitor-stats.repository';
+import { AppError } from '../../errors/AppError';
+import { toKstDateString } from '../../utils/visitor-tracking';
+import {
+  VisitorDailyBucket,
+  VisitorStatsResponse,
+} from '../dtos/admin-stats.dto';
+
+const WINDOW_DAYS = 30;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+const round4 = (value: number): number => Math.round(value * 10000) / 10000;
+
+const buildDateRange = (startDate: Date, days: number): string[] => {
+  const dates: string[] = [];
+  for (let i = 0; i < days; i++) {
+    const d = new Date(startDate.getTime() + i * DAY_MS);
+    dates.push(toKstDateString(d));
+  }
+  return dates;
+};
+
+const buildMonthDates = (month: string): string[] => {
+  if (!MONTH_PATTERN.test(month)) {
+    throw new AppError(
+      'month 파라미터는 YYYY-MM 형식이어야 합니다.',
+      400,
+      'ValidationError',
+    );
+  }
+  const [year, mon] = month.split('-').map(Number);
+  const daysInMonth = new Date(Date.UTC(year, mon, 0)).getUTCDate();
+  const dates: string[] = [];
+  for (let day = 1; day <= daysInMonth; day++) {
+    const dateStr = `${month}-${String(day).padStart(2, '0')}`;
+    dates.push(dateStr);
+  }
+  return dates;
+};
+
+export const getVisitorStats = async (
+  monthParam?: string,
+): Promise<VisitorStatsResponse> => {
+  const now = new Date();
+  const todayKst = toKstDateString(now);
+
+  const currentStart = new Date(now.getTime() - WINDOW_DAYS * DAY_MS);
+  const previousStart = new Date(
+    currentStart.getTime() - WINDOW_DAYS * DAY_MS,
+  );
+
+  const currentDates = buildDateRange(currentStart, WINDOW_DAYS);
+  const previousDates = buildDateRange(previousStart, WINDOW_DAYS);
+
+  const [daily_count, current_count, previous_count] = await Promise.all([
+    AdminVisitorStatsRepository.countUniqueOnDate(todayKst),
+    AdminVisitorStatsRepository.countUniqueOverRange(currentDates),
+    AdminVisitorStatsRepository.countUniqueOverRange(previousDates),
+  ]);
+
+  const change_rate =
+    previous_count === 0
+      ? null
+      : round4((current_count - previous_count) / previous_count);
+
+  let month: string | null = null;
+  let month_total: number | null = null;
+  let month_daily: VisitorDailyBucket[] | null = null;
+
+  if (monthParam) {
+    const monthDates = buildMonthDates(monthParam);
+    const [total, dailyBuckets] = await Promise.all([
+      AdminVisitorStatsRepository.countUniqueOverRange(monthDates),
+      AdminVisitorStatsRepository.countUniquePerDay(monthDates),
+    ]);
+    month = monthParam;
+    month_total = total;
+    month_daily = dailyBuckets;
+  }
+
+  return {
+    daily_count,
+    window_days: WINDOW_DAYS,
+    current_count,
+    previous_count,
+    change_rate,
+    month,
+    month_total,
+    month_daily,
+  };
+};

--- a/src/utils/visitor-tracking.ts
+++ b/src/utils/visitor-tracking.ts
@@ -1,0 +1,58 @@
+import { createHash } from 'crypto';
+import { Request } from 'express';
+import redisClient from '../config/redis';
+
+const HLL_KEY_PREFIX = 'visitors:hll:';
+const HLL_TTL_SECONDS = 60 * 60 * 24 * 400;
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+const BOT_UA_PATTERN =
+  /bot|crawl|spider|scrape|preview|monitor|uptime|curl|wget|python-requests|node-fetch|axios|http-client|libwww|java\/|okhttp/i;
+
+export const toKstDateString = (date: Date): string =>
+  new Date(date.getTime() + KST_OFFSET_MS).toISOString().slice(0, 10);
+
+export const buildHllKey = (kstDate: string): string =>
+  `${HLL_KEY_PREFIX}${kstDate}`;
+
+export const isBotUserAgent = (ua: string | undefined): boolean => {
+  if (!ua) return true;
+  return BOT_UA_PATTERN.test(ua);
+};
+
+export const getClientIp = (req: Request): string => {
+  const xff = req.headers['x-forwarded-for'];
+  if (typeof xff === 'string' && xff.length > 0) {
+    return xff.split(',')[0].trim();
+  }
+  return req.ip || req.socket.remoteAddress || 'unknown';
+};
+
+const hashIp = (ip: string): string => {
+  const salt = process.env.VISITOR_HASH_SALT ?? '';
+  return createHash('sha256').update(`${ip}:${salt}`).digest('hex').slice(0, 24);
+};
+
+export const computeVisitorId = (req: Request): string => {
+  const userId = (req.user as { user_id?: number } | undefined)?.user_id;
+  if (userId) {
+    return `u:${userId}`;
+  }
+  return `i:${hashIp(getClientIp(req))}`;
+};
+
+export const recordVisit = async (
+  visitorId: string,
+  date: Date = new Date(),
+): Promise<void> => {
+  try {
+    const key = buildHllKey(toKstDateString(date));
+    await redisClient.pfAdd(key, visitorId);
+    await redisClient.expire(key, HLL_TTL_SECONDS);
+  } catch (error) {
+    console.error('[visitor-tracking] failed to record visit', {
+      visitorId,
+      error,
+    });
+  }
+};

--- a/swagger.json
+++ b/swagger.json
@@ -7500,6 +7500,116 @@
         }
       }
     },
+    "/api/admin/stats/visitors": {
+      "get": {
+        "summary": "방문자 통계 조회",
+        "description": "방문자 통계를 조회합니다. 모든 카운트는 KST(Asia/Seoul) 캘린더 기준이며 Redis HyperLogLog를 사용해 고유 방문자 수를 추정(오차 ~0.81%)합니다.\n\n- `daily_count`: 오늘(KST) 고유 방문자 수\n- `current_count`: 최근 30일 롤링 윈도우 고유 방문자 수 (합집합)\n- `previous_count`: 그 이전 30일 (now-60d ~ now-30d) 고유 방문자 수\n- `change_rate`: `(current - previous) / previous` (소수 4자리). 이전 구간 0이면 `null`\n- `?month=YYYY-MM` 파라미터 제공 시 `month_total`(해당 월 고유 방문자 합) + `month_daily`(일별 분포) 함께 반환\n\n활동 기록은 모든 비-봇 API 요청에서 KST 일별 HyperLogLog 키에 `PFADD`로 누적됩니다.\n",
+        "tags": [
+          "AdminStats"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "month",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-(0[1-9]|1[0-2])$",
+              "example": "2026-05"
+            },
+            "description": "특정 월의 일별 분포 조회 (선택)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "방문자 통계를 조회했습니다."
+                    },
+                    "statusCode": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "daily_count": {
+                          "type": "integer",
+                          "example": 312
+                        },
+                        "window_days": {
+                          "type": "integer",
+                          "example": 30
+                        },
+                        "current_count": {
+                          "type": "integer",
+                          "example": 9450
+                        },
+                        "previous_count": {
+                          "type": "integer",
+                          "example": 8200
+                        },
+                        "change_rate": {
+                          "type": "number",
+                          "nullable": true,
+                          "example": 0.1524
+                        },
+                        "month": {
+                          "type": "string",
+                          "nullable": true,
+                          "example": "2026-05"
+                        },
+                        "month_total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "example": 8970
+                        },
+                        "month_daily": {
+                          "type": "array",
+                          "nullable": true,
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "date": {
+                                "type": "string",
+                                "example": "2026-05-01"
+                              },
+                              "count": {
+                                "type": "integer",
+                                "example": 287
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "잘못된 month 파라미터 형식"
+          },
+          "401": {
+            "description": "인증 실패"
+          },
+          "403": {
+            "description": "권한 없음"
+          }
+        }
+      }
+    },
     "/api/admin/stats/prompts/new": {
       "get": {
         "summary": "신규 프롬프트 통계 조회",


### PR DESCRIPTION
## 📌 기능 설명
관리자 대시보드의 **방문자 지표**를 위한 추적 인프라와 통계 API를 구현합니다.
관련 이슈: #461

## 📌 구현 내용

### 1. 추적 인프라
- **저장**: Redis HyperLogLog (`PFADD` / `PFCOUNT`)
  - 키: `visitors:hll:YYYY-MM-DD` (KST 캘린더)
  - 메모리 O(1), 오차 ~0.81%
  - TTL 400일 (지난 1년 월별 조회 지원)
- **방문자 식별**
  - 로그인 사용자: `u:{user_id}`
  - 비로그인: `i:{sha256(ip + VISITOR_HASH_SALT) 24글자}`
- **봇 필터**: User-Agent 정규식 매칭
  ```
  /bot|crawl|spider|scrape|preview|monitor|uptime|curl|wget|python-requests|node-fetch|axios|http-client|libwww|java\/|okhttp/i
  ```
- **미들웨어**
  - `src/middlewares/visitorTracker.ts`
  - 모든 요청에 mount, `/health`·`/api-docs`·`/uploads`·`/api/notifications/sse` 제외
  - `OPTIONS`/`HEAD` 제외
  - **`res.on('finish')` 훅으로 응답 종료 시 발화** → 인증 후 `req.user`가 채워진 뒤 visitor_id 확정
  - 4xx/5xx 응답은 카운트 제외

### 2. 통계 API

| 메서드 | 경로 | 동작 |
|--------|------|------|
| `GET` | `/api/admin/stats/visitors` | 방문자 통계 (롤링 30일 + 옵션 월별 분포) |

`authenticateJwt` + `isAdmin` 적용.

#### 응답 예시
```json
{
  "data": {
    "daily_count": 312,
    "window_days": 30,
    "current_count": 9450,
    "previous_count": 8200,
    "change_rate": 0.1524,
    "month": "2026-05",
    "month_total": 8970,
    "month_daily": [
      { "date": "2026-05-01", "count": 287 },
      "..."
    ]
  }
}
```
`?month` 미지정 시 `month`, `month_total`, `month_daily`는 `null`.

### 3. 설계 결정
- **HyperLogLog 채택 근거**: SET 대비 메모리 O(1), 운영 통계에는 ~0.81% 오차 허용 가능
- **`res.on('finish')` 훅**: 미들웨어가 라우트 인증 이전에 실행되더라도 응답 종료 시점엔 `req.user`가 세팅되어 있어 로그인 사용자 식별 가능
- **IP 해싱**: 평문 IP를 Redis에 저장하지 않음 (개인정보 보호)
- **`VISITOR_HASH_SALT`** 환경변수: 미설정 시 빈 문자열 fallback. 운영 환경에 추가 권장

### 변경 파일
- `src/utils/visitor-tracking.ts` — 신규 (식별·해싱·기록 유틸)
- `src/middlewares/visitorTracker.ts` — 신규 (Express 미들웨어)
- `src/stats/repositories/admin-visitor-stats.repository.ts` — 신규 (PFCOUNT 래퍼)
- `src/stats/services/admin-visitor-stats.service.ts` — 신규 (날짜 범위 빌더 + 집계)
- `src/stats/controllers/admin-visitor-stats.controller.ts` — 신규
- `src/stats/routes/admin-stats.route.ts` — `/visitors` 라우트 + Swagger
- `src/stats/dtos/admin-stats.dto.ts` — visitor stats DTO 추가
- `src/index.ts` — `visitorTracker` 전역 mount
- `swagger.json` — 빌드 시 자동 재생성

## 📌 구현 결과
- `pnpm build` 통과 (tsc 0 errors)
- Swagger `/api-docs` → `AdminStats` 태그에 신규 API 표시

## 📌 논의하고 싶은 점
- **`VISITOR_HASH_SALT` 추가 필요**: GitHub Actions의 `ENV_CONTENT`/`ENV_DEV_CONTENT` 시크릿에 추가 권장. 미설정 시에도 동작은 하지만 같은 IP가 다른 환경에서 동일 해시 → 약한 익명성
- **HyperLogLog 오차 ~0.81%**: 방문자 수가 1만일 때 ±80명 오차. 운영 통계 용도로 충분하다고 판단했지만 정확도 더 필요하면 SET 또는 DB로 변경 가능
- **로그인/비로그인 동일 사용자 중복 카운트 가능성**: 한 사용자가 한 세션에서 로그아웃→로그인 시 `i:hash(ip)`와 `u:{user_id}` 둘 다 누적될 수 있음. 일반적 사용 패턴에서는 미미함
- **봇 UA 정규식**: 패턴 누락 시 봇 트래픽이 카운트될 수 있음. 운영하며 추가/조정 필요