### PR TITLE
[FEAT] 정산관리 - 정산 계좌 정보 응답에 생년월일 포함 (#476)

### DIFF
--- a/src/settlements/dtos/settlement.dto.ts
+++ b/src/settlements/dtos/settlement.dto.ts
@@ -38,6 +38,7 @@ export interface AccountDataDto {
   bank: string;
   accountNumber: string;
   holderName: string;
+  birthDate?: string; // YYMMDD. CORPORATE는 null (응답에서 생략)
 }
 
 export interface ViewAccountResponseDto {

--- a/src/settlements/routes/settlement.route.ts
+++ b/src/settlements/routes/settlement.route.ts
@@ -189,6 +189,7 @@ router.post("/verify-account", authenticateJwt, verifyAccount);
  *                     bank: { type: string, example: "088" }
  *                     accountNumber: { type: string, example: "1234567890" }
  *                     holderName: { type: string, example: 홍길동 }
+ *                     birthDate: { type: string, nullable: true, description: 예금주 생년월일 YYMMDD. CORPORATE는 null, example: "880212" }
  *                 statusCode: { type: integer, example: 200 }
  *       401:
  *         description: 로그인 필요

--- a/src/settlements/services/settlement.account.service.ts
+++ b/src/settlements/services/settlement.account.service.ts
@@ -141,6 +141,7 @@ export const getAccountInfo = async (userId: number): Promise<AccountDataDto> =>
     bank: account.bank_code,
     accountNumber: account.account_number,
     holderName: account.account_holder,
+    birthDate: account.birth_date ?? undefined,
   };
 };
 

--- a/swagger.json
+++ b/swagger.json
@@ -7089,6 +7089,12 @@
                         "holderName": {
                           "type": "string",
                           "example": "홍길동"
+                        },
+                        "birthDate": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "예금주 생년월일 YYMMDD. CORPORATE는 null",
+                          "example": "880212"
                         }
                       }
                     },


### PR DESCRIPTION
## Summary

#473에서 정보 변경 화면용 `GET /account/detail`에만 birthDate를 추가했는데, 정산관리 화면이 사용하는 `GET /accounts` 응답에도 동일하게 포함시킵니다. PR #474 머지 직후 push되어 누락된 단일 커밋(`17de9b6`)을 develop 최신 기준으로 cherry-pick 한 follow-up.

### 변경
- `AccountDataDto.birthDate` 추가 (CORPORATE는 null/생략)
- `getAccountInfo` 응답에 `birth_date` 포함
- `/accounts` Swagger 갱신

## Test plan
- [x] `pnpm build` / `pnpm tsc --noEmit` 통과
- [ ] 프론트엔드에서 `/accounts` 응답의 birthDate 표시 확인 후 머지

Closes #476
Related: #473, #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)