### PR TITLE
[CI] 배포 파이프라인 시간 단축 — 이중 빌드 제거 + prune 완화 + .dockerignore 보강 (#499)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,12 +7,16 @@ coverage
 # 깃 관련 파일
 .git
 .gitignore
+.github
 
 # 환경 변수
 .env
 .env.dev
+.env.local
+.env.*.local
 
 # 로그 파일
+*.log
 npm-debug.log
 yarn-error.log
 pnpm-debug.log
@@ -28,3 +32,18 @@ docker-compose.yml
 
 # 빌드에 필요 없는 파일
 README.md
+*.md
+docs
+
+# 테스트/임시 파일
+tests
+__tests__
+*.test.ts
+*.spec.ts
+
+# IDE 설정
+.vscode
+.idea
+
+# Swagger 산출물 (컨테이너 빌드 시 재생성)
+swagger.json

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -2,7 +2,7 @@ name: deploy-dev
 
 on:
   push:
-    branches: [ develop ] 
+    branches: [ develop ]
   workflow_dispatch:
 
 jobs:
@@ -48,27 +48,22 @@ jobs:
           ${{ secrets.ENV_DEV_CONTENT }}
           EOF'
 
-      - name: Install, Generate & Build on server
-        run: |
-          ssh prod 'cd /opt/app-dev && pnpm install --frozen-lockfile && pnpm exec prisma generate && rm -rf dist && pnpm build'
-      
-      # 테스트 DB 마이그레이션
+      # 테스트 DB 마이그레이션 (npx로 prisma CLI 1회 호출 — EC2 build 단계 없이)
       - name: Run Prisma DB Push (Dev)
         run: |
           ssh prod << 'EOF'
           set -euo pipefail
           cd /opt/app-dev
-          # .env.dev 파일을 로드하여 실행
-          export $(cat .env.dev | xargs)
-          pnpm exec prisma db push
+          export $(grep -v '^#' .env.dev | xargs)
+          npx --yes -p prisma@^6 prisma db push
           EOF
 
-      # 도커 빌드 전 디스크 용량 확보
-      - name: Clean up unused Docker data on EC2
+      # 도커 빌드 전 디스크 정리 (7일 이상 미사용 데이터만 — BuildKit 캐시 보존)
+      - name: Prune stale Docker data on EC2
         run: |
-          ssh prod 'sudo docker system prune -af'
+          ssh prod 'sudo docker system prune -f --filter "until=168h" || true'
 
-      # app-dev 컨테이너만 재시작 (운영 컨테이너 app, caddy는 건드리지 않음)
+      # app-dev 컨테이너만 빌드/재시작 (install/generate/build는 Dockerfile 멀티스테이지로 통합)
       - name: Deploy Docker services (Dev)
         run: |
           ssh prod 'cd /opt/app-dev && sudo docker compose -p promptplace -f docker-compose.yml up -d --build app-dev'

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy: 
+  deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -53,23 +53,22 @@ jobs:
           ${{ secrets.ENV_CONTENT }}
           EOF'
 
-      - name: Install, Generate & Build on server
-        run: |
-          ssh prod 'cd /opt/app-backup && pnpm install --frozen-lockfile && pnpm exec prisma generate && rm -rf dist && pnpm build'
-
+      # Prisma 마이그레이션 (npx로 prisma CLI 1회 호출 — EC2 build 단계 없이)
       - name: Run Prisma migrations (deploy)
         if: steps.paths-filter.outputs.prisma == 'true'
         run: |
           ssh prod << 'EOF'
           set -euo pipefail
           cd /opt/app-backup
-          pnpm exec prisma migrate deploy
+          export $(grep -v '^#' .env | xargs)
+          npx --yes -p prisma@^6 prisma migrate deploy
           EOF
 
       - name: Stop and Remove old containers
         run: |
           ssh prod 'cd /opt/app-backup && sudo docker rm -f myapp || true && sudo docker rm -f caddy || true'
 
+      # Docker 빌드/배포 (install/generate/build는 Dockerfile 멀티스테이지로 통합)
       - name: Deploy Docker services
-        run: | 
+        run: |
           ssh prod 'cd /opt/app-backup && sudo docker compose -p promptplace -f docker-compose.yml up -d --build app caddy'


### PR DESCRIPTION
## Summary

2개 에이전트 교차 검증 결과 CRITICAL 3건만 묶음. PR-A. 후속 HIGH(BuildKit GHA cache)는 별도 PR.

### 커밋 분리
| # | 커밋 | 내용 |
|---|---|---|
| 1 | `7ec8dd3` | 이중 빌드 제거 (`deploy-develop`/`deploy-main` "Install/Generate/Build on server" 단계 삭제) + Prisma migrate를 npx로 단순화 + develop의 `docker system prune -af` → `prune -f --filter "until=168h"` 완화 |
| 2 | `8dcafaa` | .dockerignore 보강 (.github, *.md, tests, swagger.json 등 추가) |

## 핵심 변경

### 1. 이중 빌드 제거 (가장 큰 효과)
- 워크플로 두 곳의 `Install, Generate & Build on server` 단계를 EC2에서 수행하던 `pnpm install + prisma generate + tsc build`가 Dockerfile 멀티스테이지에서도 동일 수행 → 100% 중복
- 삭제. 이제 Dockerfile만 빌드.
- Prisma 마이그레이션(`db push` for dev, `migrate deploy` for main)은 EC2에 prisma CLI가 없으므로 **`npx --yes -p prisma@^6 prisma`**로 1회 실행

### 2. BuildKit 캐시 보존
- `docker system prune -af`(layer cache까지 전부 삭제) → `prune -f --filter "until=168h"`(7일 이상만)
- 매 배포가 cold build였던 문제 해소

### 3. `.dockerignore` 보강
- `.github`, `*.md`, `tests`, `*.test.ts`, `swagger.json`, `.vscode` 등 추가
- 빌드 context 전송 크기 감소 + layer 캐시 무효화 빈도 감소

## 추정 효과
| 단계 | 변경 전 | 변경 후 (예상) |
|---|---|---|
| EC2 install + build | ~80초 | 0초 (삭제) |
| Prisma migrate | ~15초 (full install + generate + db push) | ~10초 (npx prisma만) |
| Docker build (cache hit 시) | ~70초 (cold) | ~20~40초 (layer cache 활용) |
| **합계** | **3분+** | **1분 30초 ~ 1분 50초** |

## 별도 이슈로 분리 (후속)
- GitHub Actions BuildKit GHA cache (`docker/build-push-action@v5` + `cache-from: type=gha`) — 추가 ~30초 절감 기대
- TypeScript incremental 빌드 (이중 빌드 제거 후 효과 제한적)
- Prisma CLI를 dependencies로 이동 검토 (npx 다운로드 비용 ~10초 제거)

## Test plan
- [ ] develop에 머지 후 자동 배포 시간 측정 (전/후 비교)
- [ ] app-dev 컨테이너 정상 기동 + healthcheck 통과
- [ ] `npx prisma db push` 정상 수행 (스키마 변경 시)
- [ ] BuildKit cache가 다음 배포에 활용되는지 확인 (layer reuse 로그)

## 운영 안전성 메모
- main 배포는 `prisma migrate deploy`만 schema 변경 시 실행 (paths-filter 유지)
- EC2의 `node_modules`는 더 이상 만들어지지 않음 (rsync로 이전 잔존본은 첫 deploy 시 `--delete`로 정리)
- npx prisma 첫 호출 시 ~10초 다운로드, 이후 캐시

Closes #499