### PR TITLE
[FIX] 정산 4개 Payple 유틸에 Referer 헤더 추가 (#503)

### DIFF
--- a/src/settlements/utils/payple-billing.ts
+++ b/src/settlements/utils/payple-billing.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import redisClient from '../../config/redis';
 import { AppError } from '../../errors/AppError';
-import { redactPaypleLog } from './payple';
+import { redactPaypleLog, buildPaypleHeaders } from './payple';
 
 // Payple 빌링키 라이프사이클 (#491 후속 작업 대비).
 // 본 파일은 빌링키 조회(PUSERINFO) / 해지(PUSERDEL) 인프라만 정의.
@@ -67,7 +67,7 @@ const fetchBillingAuth = async (work: BillingWork): Promise<BillingAuth> => {
   const res = await axios.post(
     url,
     { cst_id: cstId, custKey, PCD_PAY_WORK: work },
-    { headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' } },
+    { headers: buildPaypleHeaders() },
   );
 
   if (res.data?.result !== 'success') {
@@ -113,7 +113,7 @@ export const fetchBillingKeyInfo = async (payerId: string): Promise<BillingKeyIn
       PCD_AUTH_KEY: auth.authKey,
       PCD_PAYER_ID: payerId,
     },
-    { headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' } },
+    { headers: buildPaypleHeaders() },
   );
 
   if (res.data?.PCD_PAY_RST !== 'success') {
@@ -165,7 +165,7 @@ export const deleteBillingKey = async (payerId: string): Promise<BillingKeyDelet
       PCD_AUTH_KEY: auth.authKey,
       PCD_PAYER_ID: payerId,
     },
-    { headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' } },
+    { headers: buildPaypleHeaders() },
   );
 
   if (res.data?.PCD_PAY_RST !== 'success') {

--- a/src/settlements/utils/payple-refund.ts
+++ b/src/settlements/utils/payple-refund.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import redisClient from '../../config/redis';
 import { AppError } from '../../errors/AppError';
-import { redactPaypleLog } from './payple';
+import { redactPaypleLog, buildPaypleHeaders } from './payple';
 
 // Payple 결제 취소(환불) 유틸.
 // PCD_PAYCANCEL_FLAG=Y로 파트너 인증 → 응답의 PCD_PAY_HOST + PCD_PAY_URL로 취소 요청.
@@ -69,7 +69,7 @@ const fetchRefundAuth = async (): Promise<PaypleRefundAuth> => {
   const res = await axios.post(
     url,
     { cst_id: cstId, custKey, PCD_PAYCANCEL_FLAG: 'Y' },
-    { headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' } },
+    { headers: buildPaypleHeaders() },
   );
 
   if (res.data?.result !== 'success') {
@@ -123,7 +123,7 @@ export const requestPaypleRefund = async (
   let res;
   try {
     res = await axios.post(url, body, {
-      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' },
+      headers: buildPaypleHeaders(),
     });
   } catch (err: any) {
     console.error('[payple-refund] request network error', {

--- a/src/settlements/utils/payple-settlement.ts
+++ b/src/settlements/utils/payple-settlement.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import redisClient from '../../config/redis';
 import { AppError } from '../../errors/AppError';
-import { redactPaypleLog } from './payple';
+import { redactPaypleLog, buildPaypleHeaders } from './payple';
 
 // Payple 정산내역 조회용 파트너 인증 + 조회 유틸.
 // 정산내역 조회는 PCD_SETTLEMENT_FLAG=Y로 인증 받고, 응답의 PCD_PAY_HOST + PCD_PAY_URL로 호출.
@@ -68,7 +68,7 @@ export const fetchPaypleSettlementAuth = async (): Promise<PaypleSettlementAuth>
   const res = await axios.post(
     url,
     { cst_id: cstId, custKey, PCD_SETTLEMENT_FLAG: 'Y' },
-    { headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' } },
+    { headers: buildPaypleHeaders() },
   );
 
   if (res.data?.result !== 'success') {
@@ -146,7 +146,7 @@ export const fetchPaypleSettlements = async (
 
   const url = `${auth.payHost}${auth.payUrl}`;
   const res = await axios.post(url, body, {
-    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' },
+    headers: buildPaypleHeaders(),
   });
 
   if (res.data?.PCD_PAY_RST !== 'success') {

--- a/src/settlements/utils/payple.ts
+++ b/src/settlements/utils/payple.ts
@@ -21,6 +21,15 @@ export class AccountVerificationError extends AppError {
   }
 }
 
+// Payple 호출 공통 헤더.
+// AWS 등 클라우드 환경에서 도메인 정보가 누락되는 경우를 대비해 Referer 헤더를 함께 전송 (Payple 안내사항).
+export const buildPaypleHeaders = (extra?: Record<string, string>): Record<string, string> => ({
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-cache',
+  ...(process.env.PAYPLE_REFERER ? { Referer: process.env.PAYPLE_REFERER } : {}),
+  ...extra,
+});
+
 // 민감 정보 redactor — 로그에 노출되면 안 되는 필드
 const REDACTED_FIELDS = new Set([
   // 실명인증/은행/토큰
@@ -106,7 +115,7 @@ const fetchPaypleAccessToken = async (): Promise<string> => {
   const res = await axios.post(
     `${PAYPLE_HUB_URL}/oauth/token`,
     { cst_id, custKey, code },
-    { headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' } },
+    { headers: buildPaypleHeaders() },
   );
 
   if (res.data.result !== 'T0000') {
@@ -192,11 +201,7 @@ export const verifyRealNameWithPayple = async (
         account_holder_info: holderInfo,
       },
       {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          'Content-Type': 'application/json',
-          'Cache-Control': 'no-cache',
-        },
+        headers: buildPaypleHeaders({ Authorization: `Bearer ${accessToken}` }),
       },
     );
   } catch (err: any) {


### PR DESCRIPTION
## Summary

Payple 안내사항 2번("AWS 등 클라우드에서 도메인 정보가 전송되지 않는 경우 → Referer 헤더로 도메인 설정")에 따라, 결제 유틸에만 있던 Referer 헤더를 정산 4개 유틸에도 일관 적용.

### 변경
- **`utils/payple.ts`에 `buildPaypleHeaders()` 헬퍼 추가**
  - `Content-Type` + `Cache-Control` + `Referer`(PAYPLE_REFERER 있을 때만)
  - `extra` 인자로 Authorization 등 호출별 헤더 병합 가능
- 4개 유틸의 모든 `axios.post` 헤더가 `buildPaypleHeaders()` 사용:
  - `utils/payple.ts` (실명인증 OAuth + `/inquiry/real_name`)
  - `utils/payple-settlement.ts` (정산내역 조회)
  - `utils/payple-refund.ts` (결제 취소)
  - `utils/payple-billing.ts` (빌링키 조회/해지)

## 환경변수
- `PAYPLE_REFERER` — 이미 `.env`(`https://www.promptplace.kr`) / `.env.dev`(`http://localhost:5173`)에 설정됨
- 미설정 시 spread가 비어 헤더에 Referer 미포함 (안전 fallback)

## Test plan
- [x] `pnpm build` / `pnpm tsc --noEmit` 통과
- [ ] sandbox 호출 시 Referer 헤더가 실제 전송되는지 확인 (network 캡처 또는 Payple 응답 정상)
- [ ] 결제 유틸의 기존 Referer 처리와 동일하게 동작하는지 비교

Closes #503