### PR TITLE
[FEAT] verify-account 흐름에 Payple 빌링키 발급/저장 통합 (#491 PR B)

### DIFF
--- a/src/settlements/repositories/settlement.repository.ts
+++ b/src/settlements/repositories/settlement.repository.ts
@@ -7,6 +7,7 @@ export interface UpsertIndividualAccountInput {
   accountNumber: string;
   holderName: string;
   birthDate: string;            // INDIVIDUAL은 Payple 인증에 birthDate 필수
+  billingTranId?: string | null; // Payple 정산지급대행 빌링키 (#491)
 }
 
 export interface CreateBusinessAccountInput {
@@ -19,6 +20,7 @@ export interface CreateBusinessAccountInput {
   companyName: string;
   businessLicenseUrl: string;
   birthDate?: string;           // BUSINESS+PERSONAL일 때만 존재 (대표자 생년월일). CORPORATE는 undefined
+  billingTranId?: string | null; // Payple 정산지급대행 빌링키 (#491)
 }
 
 export interface UpdateBusinessAccountInput {
@@ -32,6 +34,7 @@ export interface UpdateBusinessAccountInput {
   // optional — 빈 값이면 기존 URL 유지
   businessLicenseUrl?: string | null;
   birthDate?: string;           // BUSINESS+PERSONAL일 때만 존재
+  billingTranId?: string | null; // Payple 정산지급대행 빌링키 (#491)
 }
 
 export const SettlementRepository = {
@@ -46,6 +49,7 @@ export const SettlementRepository = {
         account_number: dto.accountNumber,
         account_holder: dto.holderName,
         birth_date: dto.birthDate,
+        billing_tran_id: dto.billingTranId ?? null,
         seller_type: 'INDIVIDUAL',
         business_type: null,
         status: 'APPROVED',
@@ -61,6 +65,7 @@ export const SettlementRepository = {
         account_number: dto.accountNumber,
         account_holder: dto.holderName,
         birth_date: dto.birthDate,
+        billing_tran_id: dto.billingTranId ?? null,
         seller_type: 'INDIVIDUAL',
         status: 'APPROVED',
         is_active: true,
@@ -93,6 +98,7 @@ export const SettlementRepository = {
         representative_name: dto.representativeName,
         business_license_url: dto.businessLicenseUrl,
         birth_date: dto.birthDate ?? null,
+        billing_tran_id: dto.billingTranId ?? null,
         seller_type: 'BUSINESS',
         status: 'PENDING',
         is_active: false,
@@ -116,6 +122,7 @@ export const SettlementRepository = {
       company_name: dto.companyName,
       representative_name: dto.representativeName,
       birth_date: dto.birthDate ?? null,
+      billing_tran_id: dto.billingTranId ?? null,
       seller_type: 'BUSINESS',
       status: 'PENDING',
       is_active: false,

--- a/src/settlements/services/settlement.account.service.ts
+++ b/src/settlements/services/settlement.account.service.ts
@@ -94,7 +94,7 @@ export const verifySellerAccount = async (userId: number, dto: VerifyAccountRequ
 
   await consumePaypleRateLimit(userId);
 
-  await verifyRealNameWithPayple({
+  const { billingTranId } = await verifyRealNameWithPayple({
     userId,
     sellerType: dto.sellerType,
     businessType: dto.businessType,
@@ -118,6 +118,7 @@ export const verifySellerAccount = async (userId: number, dto: VerifyAccountRequ
     bank: dto.bank,
     accountNumber: dto.accountNumber,
     holderName: dto.holderName,
+    billingTranId,
   });
 
   return {

--- a/src/settlements/services/settlement.seller.service.ts
+++ b/src/settlements/services/settlement.seller.service.ts
@@ -83,6 +83,7 @@ export const registerIndividualSeller = async (
     accountNumber: payload.accountNumber,
     holderName: payload.holderName,
     birthDate: payload.birthDate,
+    billingTranId: payload.billingTranId,
   });
 
   const isUpdate = !!existingAccount && existingAccount.seller_type === 'INDIVIDUAL';
@@ -156,6 +157,7 @@ export const registerBusinessSeller = async (
       companyName: dto.companyName,
       businessLicenseUrl: dto.businessLicenseUrl!,
       birthDate: payload.birthDate,
+      billingTranId: payload.billingTranId,
     });
     return {
       message: '사업자 판매자 신청이 완료되었습니다. 관리자 승인 후 최종 등록됩니다.',
@@ -177,6 +179,7 @@ export const registerBusinessSeller = async (
       companyName: dto.companyName,
       businessLicenseUrl: dto.businessLicenseUrl!,
       birthDate: payload.birthDate,
+      billingTranId: payload.billingTranId,
     });
     return {
       message: '사업자 판매자 변경 신청이 완료되었습니다. 관리자 승인 후 최종 등록됩니다.',
@@ -196,6 +199,7 @@ export const registerBusinessSeller = async (
     companyName: dto.companyName,
     businessLicenseUrl: dto.businessLicenseUrl,
     birthDate: payload.birthDate,
+    billingTranId: payload.billingTranId,
   });
   return {
     message: '사업자 정보 변경 신청이 완료되었습니다. 관리자 승인 후 변경 사항이 반영됩니다.',

--- a/src/settlements/utils/payple.ts
+++ b/src/settlements/utils/payple.ts
@@ -147,9 +147,14 @@ const toSellerHint = (sellerType: 'INDIVIDUAL' | 'BUSINESS', businessType?: 'PER
 // Payple 실명-계좌 일치 인증.
 // 개인 / 개인사업자 → account_holder_info_type='0', account_holder_info=birthDate(YYMMDD)
 // 법인사업자       → account_holder_info_type='6', account_holder_info=businessNumber(10자리)
+export interface PaypleVerifyResult {
+  accountHolderName: string;
+  billingTranId: string | null;
+}
+
 export const verifyRealNameWithPayple = async (
   params: PaypleVerifyParams,
-): Promise<{ accountHolderName: string }> => {
+): Promise<PaypleVerifyResult> => {
   const { userId, sellerType, businessType, bank, accountNumber, holderName, birthDate, businessNumber } = params;
 
   if (!isValidPaypleBank(bank)) {
@@ -230,7 +235,11 @@ export const verifyRealNameWithPayple = async (
     );
   }
 
-  return { accountHolderName: res.data.account_holder_name as string };
+  // 정산지급대행 빌링키(billing_tran_id) — 향후 지급이체 호출에 필요. SettlementAccount에 저장 (#491).
+  return {
+    accountHolderName: res.data.account_holder_name as string,
+    billingTranId: (res.data.billing_tran_id as string | undefined) ?? null,
+  };
 };
 
 // Payple 실명인증 응답을 사용자 모달 8종 + 신규 3종(INVALID_BIRTHDATE / INVALID_BUSINESS_NUMBER / SYSTEM_ERROR)으로 매핑.

--- a/src/settlements/utils/register-token.ts
+++ b/src/settlements/utils/register-token.ts
@@ -24,6 +24,7 @@ export interface RegisterTokenPayload {
   bank: string;
   accountNumber: string;
   holderName: string;
+  billingTranId?: string | null;  // Payple 정산지급대행 빌링키 (#491). 발급 안 됐을 수 있음
   jti: string;
 }
 


### PR DESCRIPTION
## Summary

#491 작업 분할 PR B. Payple 정산지급대행 공식 명세를 통해 `/inquiry/real_name` 응답에 빌링키(`billing_tran_id`)가 포함되는 것을 확인 — 이 값을 받아 `SettlementAccount.billing_tran_id` 컬럼(#491 PR A에서 추가)에 저장. 향후 지급이체 API(`/transfer/execute` 등)에 필수.

### 변경
- `verifyRealNameWithPayple` 반환에 `billingTranId` 포함 (`PaypleVerifyResult` 타입 신규)
- `RegisterTokenPayload`에 `billingTranId` 추가 — verify→register 흐름에서 안전하게 전달
- `verifySellerAccount`가 verify 결과의 billingTranId를 register-token payload에 포함
- register 3개 시나리오(개인/개인사업자/법인 — 신규/개인→사업자/사업자→사업자) 모두 payload.billingTranId를 repository에 전달
- repository의 3개 input 타입(`UpsertIndividualAccountInput` / `CreateBusinessAccountInput` / `UpdateBusinessAccountInput`)에 `billingTranId` 추가
- 모든 저장 흐름이 `SettlementAccount.billing_tran_id` 컬럼에 저장

## 영향
- DB: 이번 PR 머지 후 신규 가입자/정보변경 사용자의 `billing_tran_id`가 채워지기 시작
- 기존 등록 사용자(컬럼 NULL)는 PR D(정산 사이클) 시 빌링키 없음으로 skip + alert 처리할 예정

## 후속 (PR C/D — endpoint 명세 확보 완료)
| 작업 | Endpoint (테스트) |
|---|---|
| 이체 대기 요청 | (별도 명세 필요 — 추정 `/transfer/request`) |
| 이체 실행 | `POST demohub.payple.kr/transfer/execute` |
| 이체 대기 취소 | `POST /transfer/execute` (`execute_type: CANCEL`) |
| 이체 대기 조회 | `POST /request/result/group_key` |
| 건별 결과 조회 | `POST /transfer/result` |
| 일별 결과 조회 | `POST /transfer/result/date` |
| 그룹별 결과 조회 | `POST /transfer/result/group_key` |
| 잔액 조회 | `POST /account/remain` |
| Webhook 수신 | (등록 방법/인증 명세 별도 확보 필요) |

## Test plan
- [x] `pnpm build` / `pnpm tsc --noEmit` 통과
- [ ] Payple sandbox에서 `/inquiry/real_name` 호출 응답에 `billing_tran_id` 실제 반환되는지 확인
- [ ] 신규 가입 후 SettlementAccount.billing_tran_id 컬럼에 값 저장 확인
- [ ] 환불/취소 시 빌링키 보존 여부 확인

Refs #491