### PR TITLE
[FEAT] 정산 사이클 cron + 자동 지급이체 + Webhook 수신 (#491 PR D)

### DIFF
--- a/prisma/migrations/20260524100000_add_settlement_payout/migration.sql
+++ b/prisma/migrations/20260524100000_add_settlement_payout/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable: SettlementPayout (#491 PR D)
+CREATE TABLE `SettlementPayout` (
+    `payout_id` INTEGER NOT NULL AUTO_INCREMENT,
+    `user_id` INTEGER NOT NULL,
+    `cycle_start` DATETIME(3) NOT NULL,
+    `cycle_end` DATETIME(3) NOT NULL,
+    `amount_gross` INTEGER NOT NULL DEFAULT 0,
+    `amount_refund` INTEGER NOT NULL DEFAULT 0,
+    `carry_over_prev` INTEGER NOT NULL DEFAULT 0,
+    `amount_net` INTEGER NOT NULL,
+    `billing_tran_id` VARCHAR(64) NULL,
+    `group_key` VARCHAR(64) NULL,
+    `api_tran_id` VARCHAR(64) NULL,
+    `status` ENUM('Pending','Succeed','Failed','Skipped') NOT NULL DEFAULT 'Pending',
+    `reason` VARCHAR(200) NULL,
+    `requested_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `completed_at` DATETIME(3) NULL,
+
+    UNIQUE INDEX `SettlementPayout_user_id_cycle_start_key`(`user_id`, `cycle_start`),
+    INDEX `SettlementPayout_status_idx`(`status`),
+    INDEX `SettlementPayout_cycle_start_idx`(`cycle_start`),
+    PRIMARY KEY (`payout_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `SettlementPayout` ADD CONSTRAINT `SettlementPayout_user_id_fkey`
+    FOREIGN KEY (`user_id`) REFERENCES `User`(`user_id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
   settlementAccount         SettlementAccount?
   consents                  UserConsent[]
   refunds                   Refund[]
+  payouts                   SettlementPayout[]
   chatRoomAs1               ChatRoom[]                 @relation("ChatUser1")
   chatRoomAs2               ChatRoom[]                 @relation("ChatUser2")
   sentChatMessages          ChatMessage[]              @relation("UserSentMessages")
@@ -517,6 +518,40 @@ model SettlementAccount {
   @@index([bank_code])
   @@index([account_number])
   @@index([status])
+}
+
+// 정산 사이클별 지급이체 이력 (#491 PR D).
+// 매월 15일 cron이 판매자별 net 금액(Succeed 합계 - Refunded 차감 - 이월)을 계산해 row 생성.
+// 최소 금액 미달 시 Skipped, Payple 이체 성공 시 Succeed, 실패 시 Failed.
+enum PayoutStatus {
+  Pending
+  Succeed
+  Failed
+  Skipped // 최소 금액 미달 또는 빌링키 미보유 등으로 자동 skip
+}
+
+model SettlementPayout {
+  payout_id       Int          @id @default(autoincrement())
+  user_id         Int
+  cycle_start     DateTime
+  cycle_end       DateTime
+  amount_gross    Int          @default(0) // Succeed Settlement 합계 (사이클 범위 내)
+  amount_refund   Int          @default(0) // Refunded Settlement 합계
+  carry_over_prev Int          @default(0) // 이전 사이클에서 이월된 음수 잔액 (절댓값)
+  amount_net      Int // gross - refund - carry_over_prev (최종 지급액, 음수 가능)
+  billing_tran_id String?      @db.VarChar(64) // 시점 빌링키 (SettlementAccount에서 스냅샷)
+  group_key       String?      @db.VarChar(64) // Payple 이체대기 요청 응답
+  api_tran_id     String?      @db.VarChar(64) // Payple webhook의 이체 완료 키
+  status          PayoutStatus @default(Pending)
+  reason          String?      @db.VarChar(200) // Skipped/Failed 사유
+  requested_at    DateTime     @default(now())
+  completed_at    DateTime?
+
+  user User @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+
+  @@unique([user_id, cycle_start]) // 한 사이클에 한 row만
+  @@index([status])
+  @@index([cycle_start])
 }
 
 model Review {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import promptRoutes from "./prompts/routes/prompt.route"; // 프롬프트 관련
 import ReviewRouter from "./reviews/routes/review.route";
 import purchaseRouter from "./purchases/routes/purchase.route";
 import refundRouter from "./refunds/routes/refund.route";
+import payoutWebhookRouter from "./settlements/routes/payout-webhook.route";
 import purchaseWebhookRouter from "./purchases/routes/purchase.webhook.route";
 import settlementRouter from "./settlements/routes/settlement.route";
 import withdrawalRouter from "./withdrawals/routes/withdrawal.route";
@@ -179,6 +180,7 @@ app.use("/api/tips", tipRouter);
 // 정산 라우터
 app.use("/api/settlements", settlementRouter);
 app.use("/api/settlements", withdrawalRouter);
+app.use("/api/payouts", payoutWebhookRouter);
 
 //공지사항 라우터
 app.use("/api/announcements", announcementRouter);

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import chatRouter from "./chat/routes/chat.route";
 import { initSocket } from "./socket/server";
 import { startPromptStatSnapshotJob } from "./stats/jobs/prompt-stat-snapshot.job";
 import { startSettlementSyncJob } from "./settlements/jobs/settlement-sync.job";
+import { startSettlementPayoutJob } from "./settlements/jobs/settlement-payout.job";
 import morgan = require('morgan');
 const PORT = 3000;
 const app = express();
@@ -50,6 +51,7 @@ const server = http.createServer(app);
 initSocket(server)
 startPromptStatSnapshotJob();
 startSettlementSyncJob();
+startSettlementPayoutJob();
 // 1. 응답 핸들러(json 파서보다 위에)
 app.use(responseHandler);
 app.use((req, res, next) => {

--- a/src/settlements/controllers/payout-webhook.controller.ts
+++ b/src/settlements/controllers/payout-webhook.controller.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from 'express';
+import { SettlementPayoutRepository } from '../repositories/settlement-payout.repository';
+import { redactPaypleLog } from '../utils/payple';
+
+// Payple 정산지급대행 이체 결과 webhook 수신 (#491 PR D).
+// 명세상 인증 방식 미명시 — 운영 전 IP allowlist 또는 shared-secret 별도 적용 권장.
+// 본 컨트롤러는 group_key로 SettlementPayout을 찾아 status를 Succeed/Failed로 마감.
+// 멱등성: 이미 Pending이 아니면 200으로 응답하고 변경 안 함.
+
+export const handlePayoutWebhook = async (req: Request, res: Response) => {
+  const body = req.body ?? {};
+  const result = body.result as string | undefined;
+  const groupKey = body.group_key as string | undefined;
+  const apiTranId = body.api_tran_id as string | undefined;
+  const message = body.message as string | undefined;
+
+  if (!groupKey) {
+    console.error('[payout-webhook] missing group_key', { body: redactPaypleLog(body) });
+    return res.status(400).json({ error: 'BadRequest', message: 'group_key 누락', statusCode: 400 });
+  }
+
+  const payout = await SettlementPayoutRepository.findPayoutByGroupKey(groupKey);
+  if (!payout) {
+    // 멱등 — 이미 마감됐거나 매칭 없음. 200으로 응답해 Payple 재전송 방지.
+    console.warn('[payout-webhook] no Pending payout for group_key', { groupKey });
+    return res.status(200).json({ ok: true });
+  }
+
+  try {
+    if (result === 'A0000') {
+      await SettlementPayoutRepository.markSucceeded(payout.payout_id, apiTranId ?? '');
+      console.log('[payout-webhook] payout succeeded', { payoutId: payout.payout_id, apiTranId });
+    } else {
+      const reason = `Payple webhook ${result ?? 'UNKNOWN'} - ${message ?? ''}`;
+      await SettlementPayoutRepository.markFailed(payout.payout_id, reason);
+      console.error('[payout-webhook] payout failed', { payoutId: payout.payout_id, reason });
+    }
+    return res.status(200).json({ ok: true });
+  } catch (err: any) {
+    console.error('[payout-webhook] update failed', { error: err?.message });
+    return res.status(500).json({ error: 'InternalServerError', statusCode: 500 });
+  }
+};

--- a/src/settlements/jobs/settlement-payout.job.ts
+++ b/src/settlements/jobs/settlement-payout.job.ts
@@ -1,0 +1,26 @@
+import cron from 'node-cron';
+import { runPayoutCycle } from '../services/settlement-payout.service';
+
+// 매월 15일 KST 09:00 — 정산 사이클 (#491 PR D).
+// 안내 사항: "정산일은 매월 15일이며, 이전 한 달 동안의 수익이 정산됩니다."
+const CRON_EXPRESSION = '0 9 15 * *';
+const TIMEZONE = 'Asia/Seoul';
+
+export const startSettlementPayoutJob = (): void => {
+  cron.schedule(
+    CRON_EXPRESSION,
+    async () => {
+      try {
+        await runPayoutCycle();
+      } catch (error) {
+        console.error('[payout-cron] scheduled run failed', error);
+      }
+    },
+    { timezone: TIMEZONE },
+  );
+
+  console.log('[payout-cron] scheduled', {
+    cron: CRON_EXPRESSION,
+    timezone: TIMEZONE,
+  });
+};

--- a/src/settlements/repositories/settlement-payout.repository.ts
+++ b/src/settlements/repositories/settlement-payout.repository.ts
@@ -1,0 +1,113 @@
+import prisma from '../../config/prisma';
+import { PayoutStatus, Status } from '@prisma/client';
+
+export const SettlementPayoutRepository = {
+  // 활성 판매자(승인 + is_active + 빌링키 보유) 목록.
+  async findEligibleSellers() {
+    return prisma.settlementAccount.findMany({
+      where: {
+        status: 'APPROVED',
+        is_active: true,
+        billing_tran_id: { not: null },
+      },
+      select: {
+        user_id: true,
+        billing_tran_id: true,
+      },
+    });
+  },
+
+  // 직전 사이클 payout의 net 음수 이월액(절댓값). 없으면 0.
+  async getCarryOverFromLastPayout(userId: number): Promise<number> {
+    const last = await prisma.settlementPayout.findFirst({
+      where: { user_id: userId },
+      orderBy: { cycle_start: 'desc' },
+      select: { amount_net: true },
+    });
+    if (!last) return 0;
+    return last.amount_net < 0 ? Math.abs(last.amount_net) : 0;
+  },
+
+  // 사이클 범위 내 gross(Succeed) / refund(Refunded) 집계.
+  async aggregateUnsettledForCycle(
+    userId: number,
+    cycleStart: Date,
+    cycleEnd: Date,
+  ): Promise<{ gross: number; refund: number }> {
+    const rows = await prisma.$queryRaw<
+      Array<{ gross: bigint | null; refund: bigint | null }>
+    >`
+      SELECT
+        SUM(CASE WHEN status = ${Status.Succeed} THEN amount ELSE 0 END) AS gross,
+        SUM(CASE WHEN status = ${Status.Refunded} THEN amount ELSE 0 END) AS refund
+      FROM Settlement
+      WHERE user_id = ${userId}
+        AND updated_at >= ${cycleStart}
+        AND updated_at < ${cycleEnd}
+    `;
+    const r = rows[0] ?? {};
+    return {
+      gross: Number(r.gross ?? 0),
+      refund: Number(r.refund ?? 0),
+    };
+  },
+
+  // 멱등성: 같은 user_id + cycle_start로 한 번만 생성.
+  async createPendingPayout(input: {
+    userId: number;
+    cycleStart: Date;
+    cycleEnd: Date;
+    amountGross: number;
+    amountRefund: number;
+    carryOverPrev: number;
+    amountNet: number;
+    billingTranId: string | null;
+    status: PayoutStatus;
+    reason?: string | null;
+  }) {
+    return prisma.settlementPayout.upsert({
+      where: { user_id_cycle_start: { user_id: input.userId, cycle_start: input.cycleStart } },
+      update: {}, // 이미 있으면 그대로 — 멱등성
+      create: {
+        user_id: input.userId,
+        cycle_start: input.cycleStart,
+        cycle_end: input.cycleEnd,
+        amount_gross: input.amountGross,
+        amount_refund: input.amountRefund,
+        carry_over_prev: input.carryOverPrev,
+        amount_net: input.amountNet,
+        billing_tran_id: input.billingTranId,
+        status: input.status,
+        reason: input.reason ?? null,
+      },
+    });
+  },
+
+  async updatePaypleGroupKey(payoutId: number, groupKey: string) {
+    return prisma.settlementPayout.update({
+      where: { payout_id: payoutId },
+      data: { group_key: groupKey },
+    });
+  },
+
+  async markFailed(payoutId: number, reason: string) {
+    return prisma.settlementPayout.update({
+      where: { payout_id: payoutId },
+      data: { status: 'Failed', reason, completed_at: new Date() },
+    });
+  },
+
+  // Webhook 수신용 — group_key 또는 billing_tran_id로 매칭.
+  async findPayoutByGroupKey(groupKey: string) {
+    return prisma.settlementPayout.findFirst({
+      where: { group_key: groupKey, status: 'Pending' },
+    });
+  },
+
+  async markSucceeded(payoutId: number, apiTranId: string) {
+    return prisma.settlementPayout.update({
+      where: { payout_id: payoutId },
+      data: { status: 'Succeed', api_tran_id: apiTranId, completed_at: new Date() },
+    });
+  },
+};

--- a/src/settlements/routes/payout-webhook.route.ts
+++ b/src/settlements/routes/payout-webhook.route.ts
@@ -1,0 +1,41 @@
+import { Router } from 'express';
+import { handlePayoutWebhook } from '../controllers/payout-webhook.controller';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /api/payouts/webhook:
+ *   post:
+ *     summary: Payple 정산지급대행 이체 결과 webhook 수신
+ *     description: |
+ *       executePayout(NOW) 요청 시 첨부한 webhook_url로 Payple이 이체 결과를 전송.
+ *       group_key로 SettlementPayout을 찾아 status를 Succeed/Failed로 마감.
+ *       멱등: 이미 Pending이 아니면 200 OK 응답만 (재전송 방지).
+ *
+ *       운영 전 IP allowlist 또는 shared-secret 인증 별도 적용 권장 (Payple 명세 미명시).
+ *     tags: [Settlement]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               result: { type: string, description: A0000 성공 / 그 외 실패 }
+ *               message: { type: string }
+ *               group_key: { type: string }
+ *               billing_tran_id: { type: string }
+ *               api_tran_id: { type: string }
+ *               tran_amt: { type: string }
+ *     responses:
+ *       200:
+ *         description: 멱등 처리 완료
+ *       400:
+ *         description: group_key 누락
+ *       500:
+ *         description: 서버 오류
+ */
+router.post('/webhook', handlePayoutWebhook);
+
+export default router;

--- a/src/settlements/services/settlement-payout.service.ts
+++ b/src/settlements/services/settlement-payout.service.ts
@@ -1,0 +1,182 @@
+import redisClient from '../../config/redis';
+import { SettlementPayoutRepository } from '../repositories/settlement-payout.repository';
+import { requestPayoutStandby, executePayout } from '../utils/payple-payout';
+
+// 정산 사이클 cron — 매월 15일 KST 09:00.
+// 정책 (#491):
+//  - 사이클 범위: 직전 15일 KST 00:00 ~ 이번 15일 KST 00:00 (직전 한 달)
+//  - 최소 지급액: 10,000원 미만이면 Skipped + 이월
+//  - 잔액 음수 시: 다음 사이클로 이월 (carry_over_prev로 차감)
+//  - 빌링키 미보유: Skipped + 이월 (재인증 안내는 별도)
+//  - 분산 락: Redis SET NX EX 1800
+//
+// Webhook 수신 시 결과를 Succeed/Failed로 마감 (별도 controller).
+
+const CYCLE_LOCK_KEY = 'payple:payout:cycle:lock';
+const CYCLE_LOCK_TTL_SECONDS = 30 * 60;
+const MIN_PAYOUT_AMOUNT = 10_000;
+
+// 매월 15일 KST 00:00 계산
+const getCycleBoundaries = (now: Date = new Date()): { cycleStart: Date; cycleEnd: Date } => {
+  const kstOffsetMs = 9 * 60 * 60 * 1000;
+  const nowKst = new Date(now.getTime() + kstOffsetMs);
+  const year = nowKst.getUTCFullYear();
+  const month = nowKst.getUTCMonth(); // 0-indexed
+  // 이번 15일 KST 00:00 (UTC로는 14일 15:00)
+  const cycleEndUtc = new Date(Date.UTC(year, month, 15) - kstOffsetMs);
+  // 직전 15일 KST 00:00
+  const cycleStartUtc = new Date(Date.UTC(year, month - 1, 15) - kstOffsetMs);
+  return { cycleStart: cycleStartUtc, cycleEnd: cycleEndUtc };
+};
+
+interface CycleCounters {
+  total_sellers: number;
+  paid: number;
+  skipped_min: number;
+  skipped_no_key: number;
+  failed: number;
+}
+
+const processOneSeller = async (
+  seller: { user_id: number; billing_tran_id: string | null },
+  cycle: { cycleStart: Date; cycleEnd: Date },
+  counters: CycleCounters,
+): Promise<void> => {
+  const { gross, refund } = await SettlementPayoutRepository.aggregateUnsettledForCycle(
+    seller.user_id,
+    cycle.cycleStart,
+    cycle.cycleEnd,
+  );
+  const carryOverPrev = await SettlementPayoutRepository.getCarryOverFromLastPayout(seller.user_id);
+  const amountNet = gross - refund - carryOverPrev;
+
+  // 빌링키 미보유
+  if (!seller.billing_tran_id) {
+    await SettlementPayoutRepository.createPendingPayout({
+      userId: seller.user_id,
+      cycleStart: cycle.cycleStart,
+      cycleEnd: cycle.cycleEnd,
+      amountGross: gross,
+      amountRefund: refund,
+      carryOverPrev,
+      amountNet,
+      billingTranId: null,
+      status: 'Skipped',
+      reason: '빌링키 미보유 — 계좌 재인증 필요',
+    });
+    counters.skipped_no_key += 1;
+    return;
+  }
+
+  // 최소 금액 미달 (음수도 포함)
+  if (amountNet < MIN_PAYOUT_AMOUNT) {
+    await SettlementPayoutRepository.createPendingPayout({
+      userId: seller.user_id,
+      cycleStart: cycle.cycleStart,
+      cycleEnd: cycle.cycleEnd,
+      amountGross: gross,
+      amountRefund: refund,
+      carryOverPrev,
+      amountNet,
+      billingTranId: seller.billing_tran_id,
+      status: 'Skipped',
+      reason: amountNet < 0
+        ? `음수 잔액 이월 (${amountNet}원)`
+        : `최소 지급액(${MIN_PAYOUT_AMOUNT}원) 미달`,
+    });
+    counters.skipped_min += 1;
+    return;
+  }
+
+  // Payple 이체 대기 요청 + 즉시 실행
+  const payout = await SettlementPayoutRepository.createPendingPayout({
+    userId: seller.user_id,
+    cycleStart: cycle.cycleStart,
+    cycleEnd: cycle.cycleEnd,
+    amountGross: gross,
+    amountRefund: refund,
+    carryOverPrev,
+    amountNet,
+    billingTranId: seller.billing_tran_id,
+    status: 'Pending',
+  });
+
+  try {
+    const standby = await requestPayoutStandby({
+      billingTranId: seller.billing_tran_id,
+      tranAmt: amountNet,
+      subId: `user_${seller.user_id}`,
+      distinctKey: `payout-${payout.payout_id}`,
+    });
+    await SettlementPayoutRepository.updatePaypleGroupKey(payout.payout_id, standby.groupKey);
+
+    await executePayout({
+      groupKey: standby.groupKey,
+      billingTranId: seller.billing_tran_id,
+      executeType: 'NOW',
+      webhookUrl: process.env.PAYPLE_PAYOUT_WEBHOOK_URL,
+    });
+    // 결과는 Webhook이 수신해서 Succeed/Failed로 마감
+    counters.paid += 1;
+  } catch (err: any) {
+    console.error('[payout-cycle] payple call failed', {
+      userId: seller.user_id,
+      payoutId: payout.payout_id,
+      error: err?.message,
+    });
+    await SettlementPayoutRepository.markFailed(payout.payout_id, err?.message ?? 'Payple 호출 실패');
+    counters.failed += 1;
+  }
+};
+
+export const runPayoutCycle = async (): Promise<void> => {
+  if (process.env.PAYPLE_PAYOUT_CYCLE_ENABLED === 'false') {
+    console.log('[payout-cycle] disabled by env');
+    return;
+  }
+
+  const lockAcquired = await redisClient.set(CYCLE_LOCK_KEY, '1', {
+    NX: true,
+    EX: CYCLE_LOCK_TTL_SECONDS,
+  });
+  if (lockAcquired !== 'OK') {
+    console.warn('[payout-cycle] lock held by another instance — skip this run');
+    return;
+  }
+
+  const startedAt = Date.now();
+  try {
+    const cycle = getCycleBoundaries();
+    const sellers = await SettlementPayoutRepository.findEligibleSellers();
+    const counters: CycleCounters = {
+      total_sellers: sellers.length,
+      paid: 0,
+      skipped_min: 0,
+      skipped_no_key: 0,
+      failed: 0,
+    };
+
+    for (const seller of sellers) {
+      try {
+        await processOneSeller(seller, cycle, counters);
+      } catch (err: any) {
+        counters.failed += 1;
+        console.error('[payout-cycle] seller processing failed', {
+          userId: seller.user_id,
+          error: err?.message,
+        });
+      }
+    }
+
+    console.log('[payout-cycle] completed', {
+      cycle_start: cycle.cycleStart.toISOString(),
+      cycle_end: cycle.cycleEnd.toISOString(),
+      ...counters,
+      elapsedMs: Date.now() - startedAt,
+    });
+  } catch (err: any) {
+    console.error('[payout-cycle] cycle failed', { error: err?.message });
+  } finally {
+    await redisClient.del(CYCLE_LOCK_KEY);
+  }
+};

--- a/swagger.json
+++ b/swagger.json
@@ -7101,6 +7101,57 @@
         }
       }
     },
+    "/api/payouts/webhook": {
+      "post": {
+        "summary": "Payple 정산지급대행 이체 결과 webhook 수신",
+        "description": "executePayout(NOW) 요청 시 첨부한 webhook_url로 Payple이 이체 결과를 전송.\ngroup_key로 SettlementPayout을 찾아 status를 Succeed/Failed로 마감.\n멱등: 이미 Pending이 아니면 200 OK 응답만 (재전송 방지).\n\n운영 전 IP allowlist 또는 shared-secret 인증 별도 적용 권장 (Payple 명세 미명시).\n",
+        "tags": [
+          "Settlement"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "result": {
+                    "type": "string",
+                    "description": "A0000 성공 / 그 외 실패"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "group_key": {
+                    "type": "string"
+                  },
+                  "billing_tran_id": {
+                    "type": "string"
+                  },
+                  "api_tran_id": {
+                    "type": "string"
+                  },
+                  "tran_amt": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "멱등 처리 완료"
+          },
+          "400": {
+            "description": "group_key 누락"
+          },
+          "500": {
+            "description": "서버 오류"
+          }
+        }
+      }
+    },
     "/api/settlements/verify-account": {
       "post": {
         "summary": "판매자 계좌 인증 및 register-token 발급",


### PR DESCRIPTION
## Summary

#491 작업 분할 마지막 PR (PR D). 매월 15일 KST 09:00 cron이 활성 판매자별 net 정산금을 산출해 Payple로 자동 이체. 결과는 webhook으로 수신해 SettlementPayout을 Succeed/Failed로 마감.

> ⚠️ **본 PR은 PR C(#506) 위에 쌓여 있습니다.** PR C 머지 후 PR D 머지하면 자연스럽게 정리됩니다.

### 커밋
| # | 커밋 | 내용 |
|---|---|---|
| 1 | `050d7db` | SettlementPayout 모델 + PayoutStatus enum + 마이그레이션 |
| 2 | (사이클 cron) | repository / service / job + index 부트스트랩 |
| 3 | (webhook) | controller / route + /api/payouts/webhook 등록 |

### 정산 사이클 정책 (확정)
- **사이클 범위**: 직전 15일 KST 00:00 ~ 이번 15일 KST 00:00 (직전 한 달)
- **최소 지급액**: 10,000원 미만이면 Skipped, 차이는 다음 사이클로 이월
- **음수 잔액**: 다음 사이클의 `carry_over_prev`로 차감 (이월)
- **빌링키 미보유**: Skipped + 사유 (재인증 안내)

### 핵심 흐름
```
[cron] 매월 15일 KST 09:00
  Redis 분산 락 → 활성 판매자 목록
  for each seller:
    gross = SUM(Succeed amount, 사이클 범위)
    refund = SUM(Refunded amount, 사이클 범위)
    carry_over = ABS(직전 payout.amount_net이 음수면)
    net = gross - refund - carry_over
    SettlementPayout row 생성 (멱등 upsert)
      - billing_tran_id 없음    → Skipped
      - net < 10,000원          → Skipped (이월)
      - net >= 10,000원         → Pending
        → Payple requestPayoutStandby → group_key 저장
        → executePayout(NOW, webhook_url) → 결과는 webhook 수신
  결과 카운트 로그 (paid/skipped_min/skipped_no_key/failed)

[webhook] POST /api/payouts/webhook
  group_key 매칭 → SettlementPayout 마감
    result='A0000' → markSucceeded(api_tran_id)
    else            → markFailed(reason)
  멱등: 이미 Pending이 아니면 200 OK만
```

## 환경변수 (신규)
```
PAYPLE_PAYOUT_CYCLE_ENABLED=true       # 'false'로 비활성화 (dev/임시 중단)
PAYPLE_PAYOUT_WEBHOOK_URL=https://...  # executePayout 요청에 첨부될 webhook URL
```

## 운영 배포 시 주의
- **신규 마이그레이션 1개**: `20260524100000_add_settlement_payout` (dev DB 적용 완료)
- **webhook URL**을 Payple sandbox에서 등록/검증 필요
- **webhook 인증 방식이 Payple 명세에 미명시** — 운영 전 IP allowlist 또는 shared-secret 별도 적용 권장
- 첫 사이클 (다음 15일 KST 09:00) 모니터링 권장

## 후속 (별도 이슈 권장)
- Webhook 인증 강화 (IP allowlist / shared-secret)
- 운영 모니터링 화면 (cron 결과 / 매칭 실패 alert)
- 판매자 알림 (정산 완료 / Skipped / Failed)
- `SettlementPayout` 조회 API (판매자 본인용 / admin용)
- `executePayout` 실패 후 자동 재시도 로직

## Test plan
- [x] `pnpm build` / `pnpm tsc --noEmit` 통과
- [x] dev DB 마이그레이션 적용 (데이터 보존)
- [ ] sandbox e2e:
  - 활성 판매자가 충분한 net 금액 보유 → Pending → Payple 호출 → group_key 저장
  - net < 10,000원 → Skipped
  - 빌링키 미보유 → Skipped
  - webhook 수신 시 group_key 매칭 → Succeed/Failed 마감
  - 멱등성 (같은 webhook 두 번 수신 시 안전)
- [ ] 운영 전: webhook URL 등록 + IP allowlist 보강

Refs #491