### PR TITLE
[FEAT] 채팅방 목록 last_message에 attachment_summary 추가 (#509)

### DIFF
--- a/src/chat/dtos/chat.dto.ts
+++ b/src/chat/dtos/chat.dto.ts
@@ -144,10 +144,16 @@ export interface ChatRoomListPartnerDto {
   profile_image_url: string;
 }
 
+export interface AttachmentSummaryDto {
+  image_count: number;
+  file_count: number;
+}
+
 export interface ChatRoomListLastMessageDto {
   content: string;
   sent_at: string;
   has_attachments: boolean;
+  attachment_summary: AttachmentSummaryDto | null;
 }
 
 export interface ChatRoomListItemDto{
@@ -183,11 +189,21 @@ export class ChatRoomListResponseDto {
       
       const partnerData = room.participants.find((part: any) => part.user_id !== userId);
 
-      const lastMsg = room.lastMessage ? {
-        content: room.lastMessage.content,
-        sent_at: room.lastMessage.sent_at,
-        has_attachments: room.lastMessage.attachments.length > 0
-      } : null;
+      const lastMsg = room.lastMessage ? (() => {
+        const attachments = room.lastMessage.attachments ?? [];
+        const hasAttachments = attachments.length > 0;
+        return {
+          content: room.lastMessage.content,
+          sent_at: room.lastMessage.sent_at,
+          has_attachments: hasAttachments,
+          attachment_summary: hasAttachments
+            ? {
+                image_count: attachments.filter((a: any) => a.type === "IMAGE").length,
+                file_count: attachments.filter((a: any) => a.type === "FILE").length,
+              }
+            : null,
+        };
+      })() : null;
 
       return {
         room_id: room.room_id,


### PR DESCRIPTION
## Summary

`GET /api/chat/rooms` 응답의 `last_message`에 첨부파일이 **이미지인지 파일인지**를 구분해서 내려주도록 확장. 프론트에서 마지막 메시지 미리보기에 이미지/파일 아이콘을 구분 표시할 수 있게 함.

Swagger 문서(`src/chat/routes/chat.route.ts:315-327`)에는 `attachment_summary`가 이미 명세돼 있었으나 DTO/구현이 빠져 있던 부분을 정합화.

## 변경 내용

- `ChatRoomListLastMessageDto`에 `attachment_summary: { image_count, file_count } | null` 추가
- `ChatRoomListResponseDto.from()`에서 `lastMessage.attachments`를 `type` 기준으로 카운트
  - `IMAGE` → `image_count`, `FILE` → `file_count`
  - 첨부 없으면 `attachment_summary: null` (기존 `has_attachments: false`와 일관)
- `has_attachments`는 하위 호환 유지
- Swagger는 기존 명세와 일치 → 별도 변경 없음
- repository는 이미 `lastMessage.attachments`를 include 중 → 추가 쿼리 없음

## 응답 예시

```json
"last_message": {
  "content": "...",
  "sent_at": "...",
  "has_attachments": true,
  "attachment_summary": { "image_count": 2, "file_count": 1 }
}
```

## Test plan

- [x] \`pnpm build\` / \`pnpm tsc --noEmit\` 통과
- [ ] sandbox: 이미지만 / 파일만 / 혼합 / 첨부 없음 4가지 케이스 응답 확인
- [ ] 프론트 미리보기 아이콘 분기 확인

Closes #509