### PR TITLE
[FIX] OAuth 토큰 교환 redirect_uri 동적 처리 (#512)

### DIFF
--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import AuthService from "../services/auth.service";
+import AuthService, { assertAllowedRedirectUri } from "../services/auth.service";
 import { AppError } from "../../errors/AppError";
 import { CompleteSignupDto } from "../dtos/complete-signup.dto";
 import { validate } from "class-validator";
@@ -318,7 +318,7 @@ class AuthController {
 
   async kakaoToken(req: Request, res: Response) {
     try {
-      const { code } = req.body;
+      const { code, redirect_uri } = req.body;
 
       if (!code) {
         return res.status(400).json({
@@ -328,7 +328,8 @@ class AuthController {
         });
       }
 
-      const result = await AuthService.exchangeKakaoToken(code);
+      const validatedRedirectUri = assertAllowedRedirectUri(redirect_uri);
+      const result = await AuthService.exchangeKakaoToken(code, validatedRedirectUri);
 
       res.status(200).json({
         message: "카카오 로그인이 완료되었습니다.",
@@ -354,7 +355,7 @@ class AuthController {
 
   async googleToken(req: Request, res: Response) {
     try {
-      const { code } = req.body;
+      const { code, redirect_uri } = req.body;
 
       if (!code) {
         return res.status(400).json({
@@ -364,7 +365,8 @@ class AuthController {
         });
       }
 
-      const result = await AuthService.exchangeGoogleToken(code);
+      const validatedRedirectUri = assertAllowedRedirectUri(redirect_uri);
+      const result = await AuthService.exchangeGoogleToken(code, validatedRedirectUri);
 
       res.status(200).json({
         message: "구글 로그인이 완료되었습니다.",
@@ -390,7 +392,7 @@ class AuthController {
 
   async naverToken(req: Request, res: Response) {
     try {
-      const { code } = req.body;
+      const { code, redirect_uri } = req.body;
 
       if (!code) {
         return res.status(400).json({
@@ -400,7 +402,8 @@ class AuthController {
         });
       }
 
-      const result = await AuthService.exchangeNaverToken(code);
+      const validatedRedirectUri = assertAllowedRedirectUri(redirect_uri);
+      const result = await AuthService.exchangeNaverToken(code, validatedRedirectUri);
 
       res.status(200).json({
         message: "네이버 로그인이 완료되었습니다.",

--- a/src/auth/routes/auth.route.ts
+++ b/src/auth/routes/auth.route.ts
@@ -290,11 +290,16 @@ router.post("/complete-signup", AuthController.completeSignup);
  *             type: object
  *             required:
  *               - code
+ *               - redirect_uri
  *             properties:
  *               code:
  *                 type: string
  *                 description: 카카오 OAuth 인증코드
  *                 example: "abc123def456ghi789"
+ *               redirect_uri:
+ *                 type: string
+ *                 description: OAuth 인증 시작 시 사용한 redirect_uri (서버 화이트리스트에 등록되어 있어야 함)
+ *                 example: "https://promptplace-develop.vercel.app/auth/callback"
  *     responses:
  *       200:
  *         description: 카카오 로그인 성공
@@ -425,11 +430,16 @@ router.post("/kakao/token", AuthController.kakaoToken);
  *             type: object
  *             required:
  *               - code
+ *               - redirect_uri
  *             properties:
  *               code:
  *                 type: string
  *                 description: 구글 OAuth 인증코드
  *                 example: "4/0AfJohXn..."
+ *               redirect_uri:
+ *                 type: string
+ *                 description: OAuth 인증 시작 시 사용한 redirect_uri (서버 화이트리스트에 등록되어 있어야 함)
+ *                 example: "https://promptplace-develop.vercel.app/auth/callback"
  *     responses:
  *       200:
  *         description: 구글 로그인 성공
@@ -560,11 +570,16 @@ router.post("/google/token", AuthController.googleToken);
  *             type: object
  *             required:
  *               - code
+ *               - redirect_uri
  *             properties:
  *               code:
  *                 type: string
  *                 description: 네이버 OAuth 인증코드
  *                 example: "abc123def456ghi789"
+ *               redirect_uri:
+ *                 type: string
+ *                 description: OAuth 인증 시작 시 사용한 redirect_uri (서버 화이트리스트에 등록되어 있어야 함)
+ *                 example: "https://promptplace-develop.vercel.app/auth/callback"
  *     responses:
  *       200:
  *         description: 네이버 로그인 성공

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -14,25 +14,25 @@ interface Tokens {
   refreshToken: string;
 }
 
-const getCallbackUrl = (provider: 'KAKAO' | 'GOOGLE' | 'NAVER') => {
-  const isDev = process.env.NODE_ENV !== 'production';
+const parseAllowedRedirectUris = (): Set<string> => {
+  const raw = process.env.OAUTH_ALLOWED_REDIRECT_URIS ?? "";
+  return new Set(
+    raw
+      .split(",")
+      .map((uri) => uri.trim())
+      .filter(Boolean)
+  );
+};
 
-  switch (provider) {
-    case 'KAKAO':
-      return isDev
-        ? process.env.KAKAO_CALLBACK_URL_DEV
-        : process.env.KAKAO_CALLBACK_URL;
-    case 'GOOGLE':
-      return isDev
-        ? process.env.GOOGLE_CALLBACK_URL_DEV
-        : process.env.GOOGLE_CALLBACK_URL;
-    case 'NAVER':
-      return isDev
-        ? process.env.NAVER_CALLBACK_URL_DEV
-        : process.env.NAVER_CALLBACK_URL;
-    default:
-      throw new Error('Unknown provider');
+export const assertAllowedRedirectUri = (redirectUri: string | undefined): string => {
+  if (!redirectUri) {
+    throw new AppError("redirect_uri가 필요합니다.", 400, "BadRequest");
   }
+  const allowed = parseAllowedRedirectUris();
+  if (!allowed.has(redirectUri)) {
+    throw new AppError("허용되지 않은 redirect_uri입니다.", 400, "BadRequest");
+  }
+  return redirectUri;
 };
 
 class AuthService {
@@ -109,10 +109,10 @@ class AuthService {
     };
   }
 
-  async exchangeKakaoToken(code: string) {
+  async exchangeKakaoToken(code: string, redirectUri: string) {
     try {
       // 기존 Passport 카카오 전략을 활용하여 사용자 정보 처리
-      const user = await this.handleKakaoUserFromCode(code);
+      const user = await this.handleKakaoUserFromCode(code, redirectUri);
 
       const { accessToken, refreshToken } = await this.generateTokens(user);
 
@@ -137,10 +137,10 @@ class AuthService {
     }
   }
 
-  async exchangeGoogleToken(code: string) {
+  async exchangeGoogleToken(code: string, redirectUri: string) {
     try {
       // 기존 Passport 구글 전략을 활용하여 사용자 정보 처리
-      let user = await this.handleGoogleUserFromCode(code);
+      let user = await this.handleGoogleUserFromCode(code, redirectUri);
 
       if (!isActive(user.status)) {
         const inactive = user.inactive_date
@@ -191,10 +191,10 @@ class AuthService {
     }
   }
 
-  async exchangeNaverToken(code: string) {
+  async exchangeNaverToken(code: string, redirectUri: string) {
     try {
       // 기존 Passport 네이버 전략을 활용하여 사용자 정보 처리
-      let user = await this.handleNaverUserFromCode(code);
+      let user = await this.handleNaverUserFromCode(code, redirectUri);
 
       if (!isActive(user.status)) {
         const inactive = user.inactive_date
@@ -247,7 +247,7 @@ class AuthService {
   }
 
   // 카카오 인증코드로 사용자 처리 (기존 로직 재사용)
-  private async handleKakaoUserFromCode(code: string): Promise<any> {
+  private async handleKakaoUserFromCode(code: string, redirectUri: string): Promise<any> {
     try {
       // 카카오에서 액세스 토큰 받기
       const tokenResponse = await fetch("https://kauth.kakao.com/oauth/token", {
@@ -258,7 +258,7 @@ class AuthService {
           client_id: process.env.KAKAO_CLIENT_ID!,
           client_secret: process.env.KAKAO_CLIENT_SECRET!,
           code: code,
-          redirect_uri: getCallbackUrl('KAKAO')!,
+          redirect_uri: redirectUri,
         }),
       });
 
@@ -312,7 +312,7 @@ class AuthService {
   }
 
   // 구글 인증코드로 사용자 처리 (기존 로직 재사용)
-  private async handleGoogleUserFromCode(code: string): Promise<any> {
+  private async handleGoogleUserFromCode(code: string, redirectUri: string): Promise<any> {
     try {
       // 구글에서 액세스 토큰 받기
       const tokenResponse = await fetch("https://oauth2.googleapis.com/token", {
@@ -323,7 +323,7 @@ class AuthService {
           client_id: process.env.GOOGLE_CLIENT_ID!,
           client_secret: process.env.GOOGLE_CLIENT_SECRET!,
           code: code,
-          redirect_uri: getCallbackUrl('GOOGLE')!,
+          redirect_uri: redirectUri,
         }),
       });
 
@@ -380,7 +380,7 @@ class AuthService {
   }
 
   // 네이버 인증코드로 사용자 처리 (기존 로직 재사용)
-  private async handleNaverUserFromCode(code: string): Promise<any> {
+  private async handleNaverUserFromCode(code: string, redirectUri: string): Promise<any> {
     try {
       // 네이버에서 액세스 토큰 받기
       const tokenResponse = await fetch(
@@ -393,7 +393,7 @@ class AuthService {
             client_id: process.env.NAVER_CLIENT_ID!,
             client_secret: process.env.NAVER_CLIENT_SECRET!,
             code: code,
-            redirect_uri: getCallbackUrl('NAVER')!,
+            redirect_uri: redirectUri,
           }),
         }
       );

--- a/swagger.json
+++ b/swagger.json
@@ -384,13 +384,19 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "code"
+                  "code",
+                  "redirect_uri"
                 ],
                 "properties": {
                   "code": {
                     "type": "string",
                     "description": "카카오 OAuth 인증코드",
                     "example": "abc123def456ghi789"
+                  },
+                  "redirect_uri": {
+                    "type": "string",
+                    "description": "OAuth 인증 시작 시 사용한 redirect_uri (서버 화이트리스트에 등록되어 있어야 함)",
+                    "example": "https://promptplace-develop.vercel.app/auth/callback"
                   }
                 }
               }
@@ -572,13 +578,19 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "code"
+                  "code",
+                  "redirect_uri"
                 ],
                 "properties": {
                   "code": {
                     "type": "string",
                     "description": "구글 OAuth 인증코드",
                     "example": "4/0AfJohXn..."
+                  },
+                  "redirect_uri": {
+                    "type": "string",
+                    "description": "OAuth 인증 시작 시 사용한 redirect_uri (서버 화이트리스트에 등록되어 있어야 함)",
+                    "example": "https://promptplace-develop.vercel.app/auth/callback"
                   }
                 }
               }
@@ -760,13 +772,19 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "code"
+                  "code",
+                  "redirect_uri"
                 ],
                 "properties": {
                   "code": {
                     "type": "string",
                     "description": "네이버 OAuth 인증코드",
                     "example": "abc123def456ghi789"
+                  },
+                  "redirect_uri": {
+                    "type": "string",
+                    "description": "OAuth 인증 시작 시 사용한 redirect_uri (서버 화이트리스트에 등록되어 있어야 함)",
+                    "example": "https://promptplace-develop.vercel.app/auth/callback"
                   }
                 }
               }


### PR DESCRIPTION
## Summary

OAuth 토큰 교환 시 백엔드가 `NODE_ENV` 단일 분기로 `redirect_uri`를 결정하던 구조를 제거하고, **프론트가 자신이 사용한 `redirect_uri`를 함께 전달 → 백엔드는 화이트리스트 검증 후 그대로 Provider에 전달** 하는 흐름으로 변경.

이로써 단일 백엔드 인스턴스가 **운영(`www.promptplace.kr`) / dev(`promptplace-develop.vercel.app`) / 로컬(`localhost:5173`)** 등 여러 프론트 도메인을 동시에 지원 가능.

해결한 문제: dev 백엔드를 통한 vercel-dev / 로컬 프론트의 구글·네이버·카카오 로그인이 `redirect_uri_mismatch`로 실패하던 이슈.

Closes #512

## 변경 내용

- `auth.service.ts`
  - `getCallbackUrl()` 제거 (`NODE_ENV` 단일 분기)
  - `assertAllowedRedirectUri(redirectUri)` 헬퍼 export — `OAUTH_ALLOWED_REDIRECT_URIS` (콤마 구분) 기반 화이트리스트 검증, 미통과 시 `AppError(400)`
  - `exchangeKakaoToken / exchangeGoogleToken / exchangeNaverToken` 및 private `handle*` 헬퍼 시그니처에 `redirectUri` 인자 추가, Provider 토큰 교환에 그 값 사용
- `auth.controller.ts`
  - `kakaoToken / googleToken / naverToken` 에서 body의 `redirect_uri` 추출 → `assertAllowedRedirectUri()` 검증 후 서비스로 전달
- `auth.route.ts` (Swagger)
  - `POST /api/auth/kakao/token`, `/api/auth/google/token`, `/api/auth/naver/token` 의 request body에 `redirect_uri` 필수 필드 추가
- `swagger.json`
  - prebuild에서 자동 생성된 갱신본 반영

## API 변경 (프론트 동기화 필요)

- `POST /api/auth/google/token` body에 `redirect_uri: string` 필수
- `POST /api/auth/naver/token` body에 `redirect_uri: string` 필수
- `POST /api/auth/kakao/token` body에 `redirect_uri: string` 필수
- 프론트는 OAuth 인증 시작 시 사용한 `redirect_uri`와 동일한 값을 그대로 전달해야 함

## 운영자 후속 작업

- GitHub Secret 갱신
  - `ENV_CONTENT` 에 `OAUTH_ALLOWED_REDIRECT_URIS="https://www.promptplace.kr/auth/callback"` 추가
  - `ENV_DEV_CONTENT` 에 `OAUTH_ALLOWED_REDIRECT_URIS="https://promptplace-develop.vercel.app/auth/callback,http://localhost:5173/auth/callback"` 추가
  - 두 Secret 모두 사용 안 하는 `*_CALLBACK_URL_DEV` 3종 제거 권장
- NAVER / KAKAO 디벨로퍼스 콘솔의 Redirect URI 목록에 vercel + (필요 시) localhost URL 등록
- 배포 후 검증: dev 프론트(vercel) 및 로컬 프론트(5173)에서 3종 소셜 로그인이 정상 동작하는지 확인

## 참고

- `src/config/social/*.ts`의 Passport Strategy는 여전히 `*_CALLBACK_URL`을 참조 → 환경변수는 유지
- Passport-driven flow(`GET /api/auth/login/google` 등)를 프론트가 안 쓴다면 Strategy 자체와 `*_CALLBACK_URL`도 후속 PR에서 정리 가능