### PR TITLE
[FIX] OAuth 토큰 교환 redirect_uri 누락 시 환경변수 fallback (#515)

### DIFF
--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import AuthService, { assertAllowedRedirectUri } from "../services/auth.service";
+import AuthService, { resolveRedirectUri } from "../services/auth.service";
 import { AppError } from "../../errors/AppError";
 import { CompleteSignupDto } from "../dtos/complete-signup.dto";
 import { validate } from "class-validator";
@@ -328,8 +328,8 @@ class AuthController {
         });
       }
 
-      const validatedRedirectUri = assertAllowedRedirectUri(redirect_uri);
-      const result = await AuthService.exchangeKakaoToken(code, validatedRedirectUri);
+      const resolvedRedirectUri = resolveRedirectUri("KAKAO", redirect_uri);
+      const result = await AuthService.exchangeKakaoToken(code, resolvedRedirectUri);
 
       res.status(200).json({
         message: "카카오 로그인이 완료되었습니다.",
@@ -365,8 +365,8 @@ class AuthController {
         });
       }
 
-      const validatedRedirectUri = assertAllowedRedirectUri(redirect_uri);
-      const result = await AuthService.exchangeGoogleToken(code, validatedRedirectUri);
+      const resolvedRedirectUri = resolveRedirectUri("GOOGLE", redirect_uri);
+      const result = await AuthService.exchangeGoogleToken(code, resolvedRedirectUri);
 
       res.status(200).json({
         message: "구글 로그인이 완료되었습니다.",
@@ -402,8 +402,8 @@ class AuthController {
         });
       }
 
-      const validatedRedirectUri = assertAllowedRedirectUri(redirect_uri);
-      const result = await AuthService.exchangeNaverToken(code, validatedRedirectUri);
+      const resolvedRedirectUri = resolveRedirectUri("NAVER", redirect_uri);
+      const result = await AuthService.exchangeNaverToken(code, resolvedRedirectUri);
 
       res.status(200).json({
         message: "네이버 로그인이 완료되었습니다.",

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -35,6 +35,23 @@ export const assertAllowedRedirectUri = (redirectUri: string | undefined): strin
   return redirectUri;
 };
 
+// 호환성 fallback: body의 redirect_uri가 없을 때 환경변수의 provider별 callback URL을 사용한다.
+// 프론트 단계적 반영을 위한 임시 호환 경로.
+export const resolveRedirectUri = (
+  provider: "GOOGLE" | "KAKAO" | "NAVER",
+  bodyRedirectUri: string | undefined
+): string => {
+  if (bodyRedirectUri) {
+    return assertAllowedRedirectUri(bodyRedirectUri);
+  }
+  const envKey = `${provider}_CALLBACK_URL` as const;
+  const fallback = process.env[envKey];
+  if (!fallback) {
+    throw new AppError("redirect_uri가 필요합니다.", 400, "BadRequest");
+  }
+  return fallback;
+};
+
 class AuthService {
   async generateTokens(user: any): Promise<Tokens> {
     const accessToken = jwt.sign(


### PR DESCRIPTION
## Summary

PR #513 머지 후 프론트가 `redirect_uri` body 필드를 아직 안 보내고 있어 **운영/dev 모두 소셜 로그인이 `400 redirect_uri가 필요합니다.` 로 실패** 하는 상황을 긴급 호환.

운영 콘솔 응답 (현 시점):
```json
{"error":"Error","message":"redirect_uri가 필요합니다.","statusCode":400}
```

해결: body 에 `redirect_uri` 가 **없으면 환경변수의 `*_CALLBACK_URL` 로 fallback**, **있으면 기존 화이트리스트 검증 후 사용**. 양립 가능한 호환 경로.

Closes #515

## 변경 내용

- `auth.service.ts`
  - `resolveRedirectUri(provider, bodyRedirectUri)` 헬퍼 export 추가
    - `bodyRedirectUri` 있음 → `assertAllowedRedirectUri` 통과시킨 값 반환
    - 없음 → `process.env.{PROVIDER}_CALLBACK_URL` 반환 (구 동작과 동등)
    - 환경변수도 없으면 → 400
- `auth.controller.ts`
  - `kakaoToken / googleToken / naverToken` 의 `assertAllowedRedirectUri` 호출을 `resolveRedirectUri` 로 교체
- `auth.route.ts` (Swagger)
  - `redirect_uri` 는 **`required` 유지** — 공식 계약은 새 동작으로 두고, fallback 은 코드의 임시 호환 경로
- `swagger.json` 변경 없음 (코드 빌드 결과 동일)

## 동작 매트릭스

| 요청 body | 처리 |
|---|---|
| `redirect_uri` 동봉 | 화이트리스트 검증 후 사용 (PR #513 흐름) |
| `redirect_uri` 누락 | `*_CALLBACK_URL` fallback (구 동작) |

운영(`.env`): `GOOGLE_CALLBACK_URL=https://www.promptplace.kr/auth/callback`
dev(`.env.dev`): `GOOGLE_CALLBACK_URL=https://promptplace-develop.vercel.app/auth/callback`

두 환경 모두 환경변수 그대로 fallback 동작이 정상 복원됨.

## 운영자 후속 작업

- 본 PR develop 머지 후 `develop → main` PR 도 빠르게 머지하여 운영 복구
- 프론트가 `redirect_uri` 동봉 반영 완료되면 별도 PR로 fallback 경로 제거 권장 (계약 일관성 회복)

## 보안 노트

fallback 경로는 운영자가 신뢰 설정한 환경변수만 사용 → 외부 입력 우회 없음.