### PR TITLE
[FEAT] 다운로드 목록 응답에 purchase_id / is_refunded 추가 (#518)

### DIFF
--- a/src/prompts/dtos/prompt.download.dto.ts
+++ b/src/prompts/dtos/prompt.download.dto.ts
@@ -10,6 +10,8 @@ export interface PromptDownloadResponseDTO {
 export interface DownloadedPromptResponseDTO {
   message: string;
   prompt_id: number;
+  purchase_id: number;
+  is_refunded: boolean;
   title: string;
   description: string;
   models: string[];

--- a/src/prompts/repositories/prompt.download.repository.ts
+++ b/src/prompts/repositories/prompt.download.repository.ts
@@ -28,6 +28,7 @@ export const PromptDownloadRepository = {
     return prisma.purchase.findMany({
       where: { user_id: userId },
       include: {
+        refund: { select: { refund_id: true } },
         prompt: {
           select: {
             prompt_id: true,

--- a/src/prompts/routes/prompt.download.route.ts
+++ b/src/prompts/routes/prompt.download.route.ts
@@ -98,6 +98,8 @@ router.get('/:promptId/downloads', authenticateJwt, PromptDownloadController.get
  *                     type: object
  *                     properties:
  *                       prompt_id: { type: integer }
+ *                       purchase_id: { type: integer, description: 환불 API 호출에 필요한 구매 ID }
+ *                       is_refunded: { type: boolean, description: 환불 완료 여부 }
  *                       title: { type: string }
  *                       description: { type: string, nullable: true }
  *                       price: { type: integer }

--- a/src/prompts/services/prompt.download.service.ts
+++ b/src/prompts/services/prompt.download.service.ts
@@ -95,7 +95,8 @@ async getDownloadedPrompts(userId: number): Promise<DownloadedPromptResponseDTO[
     const THIRTY_DAYS_AGO = new Date();
     THIRTY_DAYS_AGO.setDate(THIRTY_DAYS_AGO.getDate() - 30);
 
-    return downloads.map(({ prompt }) => {
+    return downloads.map((purchase) => {
+        const { prompt } = purchase;
         const userReviewRaw = prompt.reviews[0];
         const hasReview = !!userReviewRaw;
         const isRecentReview = hasReview && new Date(userReviewRaw.created_at) >= THIRTY_DAYS_AGO;
@@ -111,17 +112,19 @@ async getDownloadedPrompts(userId: number): Promise<DownloadedPromptResponseDTO[
         return {
             message: "다운로드한 프롬프트 목록 조회 성공",
             statusCode: 200,
-            
+
             prompt_id: prompt.prompt_id,
+            purchase_id: purchase.purchase_id,
+            is_refunded: !!purchase.refund,
             title: prompt.title,
              description: prompt.description,
             price: prompt.price,
             models: prompt.models.map((m) => m.model.name),
             imageUrls: imageUrls,
-            
+
             has_review: hasReview,
-            is_recent_review: isRecentReview, 
-    
+            is_recent_review: isRecentReview,
+
             userNickname: userNickname,
             userProfileImageUrl: userProfileImageUrl,
             userReview: userReview,

--- a/swagger.json
+++ b/swagger.json
@@ -3938,6 +3938,14 @@
                           "prompt_id": {
                             "type": "integer"
                           },
+                          "purchase_id": {
+                            "type": "integer",
+                            "description": "환불 API 호출에 필요한 구매 ID"
+                          },
+                          "is_refunded": {
+                            "type": "boolean",
+                            "description": "환불 완료 여부"
+                          },
                           "title": {
                             "type": "string"
                           },


### PR DESCRIPTION
## Summary

프론트 환불 기능에서 `GET /api/prompts/downloads` 응답에 `purchase_id`가 없어 환불 API(`POST /api/prompts/purchases/{purchaseId}/refund`) 호출 경로가 끊겨 있던 문제를 해결. 응답에 `purchase_id`, `is_refunded` 두 필드만 추가하는 소규모 보강.

## 변경 내용

- `PromptDownloadRepository.getDownloadedPromptsByUser` include에 `refund: { select: { refund_id: true } }` 추가
- `DownloadedPromptResponseDTO`에 `purchase_id: number`, `is_refunded: boolean` 필드 추가
- `PromptDownloadService.getDownloadedPrompts` map 콜백을 `(purchase) =>`로 변경 → `purchase.purchase_id`, `!!purchase.refund` 매핑
- Swagger 응답 스키마 갱신 + `swagger.json` 재생성
- 기존 필드 모두 유지 → 하위 호환

## 응답 예시

```jsonc
{
  "prompt_id": 12,
  "purchase_id": 345,      // 환불 API 호출용
  "is_refunded": false,    // 환불 완료 여부 (Refund 레코드 존재 시 true)
  "title": "...",
  // ...기존 필드 유지
}
```

## Test plan

- [x] `pnpm build` / `pnpm tsc --noEmit` 통과
- [ ] sandbox: 일반 구매 / 환불된 구매 / 무료 다운로드 3가지 케이스 응답 확인
- [ ] 프론트에서 `is_refunded === false` 항목에 한해 환불 버튼 노출 + 호출 경로 확인

## 기타
- 다운로드 후(`downloaded_at !== null`) 환불은 정책상 불가(#485)이나, 응답은 환불 가능 여부와 무관하게 `is_refunded`만 표시 — 환불 가능 판단은 환불 API 측에서 처리
- 관련: #485, #497, #491

Closes #518