### PR TITLE
[FIX] admin 회원 통계 social_type 대소문자 정규화 (#521)

### DIFF
--- a/prisma/migrations/20260727120000_normalize_user_social_type_uppercase/migration.sql
+++ b/prisma/migrations/20260727120000_normalize_user_social_type_uppercase/migration.sql
@@ -1,0 +1,6 @@
+-- Backfill: legacy rows had lowercase social_type ('google', 'naver', 'kakao').
+-- Current write paths (config/social/*.ts, auth.service.ts) always store uppercase,
+-- so this one-shot normalization aligns historical data with the code contract.
+UPDATE `User`
+SET `social_type` = UPPER(`social_type`)
+WHERE `social_type` IN ('google', 'naver', 'kakao');

--- a/src/stats/services/admin-stats.service.ts
+++ b/src/stats/services/admin-stats.service.ts
@@ -29,7 +29,7 @@ export const getMemberStats = async (): Promise<MemberStatsResponse> => {
   let total = 0;
 
   for (const row of grouped) {
-    const channel = SOCIAL_TYPE_TO_CHANNEL[row.social_type];
+    const channel = SOCIAL_TYPE_TO_CHANNEL[row.social_type?.toUpperCase()];
     if (!channel) continue;
     byChannel[channel].count = row._count._all;
     total += row._count._all;


### PR DESCRIPTION
## ✨ 변경 사항
- `admin-stats.service.ts` — `SOCIAL_TYPE_TO_CHANNEL` lookup 시 `row.social_type?.toUpperCase()` 로 정규화하여 대소문자와 무관하게 매칭.
- prisma 마이그레이션 `20260727120000_normalize_user_social_type_uppercase` 추가 — 기존 소문자 `social_type` (`google`/`naver`/`kakao`) 을 대문자로 일괄 백필.

## ✨ 원인
`admin-stats.service.ts` 의 매핑이 대문자 키만 정의되어 있어, dev DB 에 남아 있던 레거시 소문자 로우가 `if (!channel) continue;` 에서 버려짐. 채널 카운트뿐 아니라 `total_members` 합산에서도 제외되어 `GET /api/admin/stats/members` 응답이 실제와 크게 어긋남 (dev 기준 55 vs 실제 216).

현재 소셜 로그인 write 경로 (`config/social/*.ts`, `auth.service.ts`, `signup/repositories/signup.repository.ts`) 는 모두 대문자로 저장하므로 소문자는 순수 레거시 데이터.

## ✨ 검증 근거
dev DB 실측 (`userstatus != 'deleted'`):
```
NONE   : 54
KAKAO  : 1
google : 79   ← 마이그레이션 후 GOOGLE 로 승격
naver  : 82   ← 마이그레이션 후 NAVER 로 승격
--- total: 216
```

머지 & 배포 후 예상 응답:
```json
{
  "total_members": 216,
  "by_signup_channel": {
    "email":  { "count": 54, "ratio": 0.2500 },
    "google": { "count": 79, "ratio": 0.3657 },
    "kakao":  { "count": 1,  "ratio": 0.0046 },
    "naver":  { "count": 82, "ratio": 0.3796 }
  }
}
```

## ✨ 기타
- `pnpm build` 통과 확인.
- 프로덕션 DB 는 write 경로가 처음부터 대문자였다면 마이그레이션은 no-op. 배포 전 아래 쿼리로 대상 여부 사전 확인 권장:
  ```sql
  SELECT social_type, COUNT(*) FROM `User`
   WHERE social_type IN ('google','naver','kakao')
   GROUP BY social_type;
  ```
- `social_type` 을 사용하는 다른 read 경로 (auth 응답 필드 등) 는 값 그대로 노출할 뿐 비교 로직이 없어 백필로 인한 side-effect 없음.

Closes #521