### PR TITLE
[FIX] Redis 장애 시 방문자 통계 API hang 방지 (#524)

### DIFF
--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -2,6 +2,10 @@ import { createClient } from 'redis';
 
 const redisClient = createClient({
   url: process.env.REDIS_URL,
+  socket: {
+    connectTimeout: 3000,
+    reconnectStrategy: (retries) => Math.min(retries * 200, 5000),
+  },
 });
 
 redisClient.on('connect', () => {

--- a/src/stats/repositories/admin-visitor-stats.repository.ts
+++ b/src/stats/repositories/admin-visitor-stats.repository.ts
@@ -1,15 +1,27 @@
 import redisClient from '../../config/redis';
 import { buildHllKey } from '../../utils/visitor-tracking';
 
+const REDIS_TIMEOUT_MS = 2000;
+
+// ponytail: Redis 장애 시 응답이 hang 되지 않도록 짧은 타임아웃 + 폴백. 근본 복구는 인프라 몫.
+const withTimeout = <T>(op: Promise<T>, fallback: T): Promise<T> =>
+  Promise.race([
+    op,
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), REDIS_TIMEOUT_MS)),
+  ]);
+
 export const AdminVisitorStatsRepository = {
   countUniqueOnDate: async (kstDate: string): Promise<number> => {
-    return Number(await redisClient.pfCount(buildHllKey(kstDate)));
+    return withTimeout(
+      redisClient.pfCount(buildHllKey(kstDate)).then(Number),
+      0,
+    );
   },
 
   countUniqueOverRange: async (kstDates: string[]): Promise<number> => {
     if (kstDates.length === 0) return 0;
     const keys = kstDates.map(buildHllKey);
-    return Number(await redisClient.pfCount(keys));
+    return withTimeout(redisClient.pfCount(keys).then(Number), 0);
   },
 
   countUniquePerDay: async (
@@ -17,8 +29,10 @@ export const AdminVisitorStatsRepository = {
   ): Promise<{ date: string; count: number }[]> => {
     if (kstDates.length === 0) return [];
     const counts = await Promise.all(
-      kstDates.map((d) => redisClient.pfCount(buildHllKey(d))),
+      kstDates.map((d) =>
+        withTimeout(redisClient.pfCount(buildHllKey(d)).then(Number), 0),
+      ),
     );
-    return kstDates.map((date, i) => ({ date, count: Number(counts[i]) }));
+    return kstDates.map((date, i) => ({ date, count: counts[i] }));
   },
 };


### PR DESCRIPTION
## ✨ 변경 사항
- `src/config/redis.ts` — `createClient` 에 `socket.connectTimeout: 3000` 과 상한 있는 `reconnectStrategy` 추가. 지연 5s 로 캡.
- `src/stats/repositories/admin-visitor-stats.repository.ts` — `pfCount` 를 감싸는 `withTimeout` 헬퍼 (2s) 도입. 각 메서드가 Redis 응답을 못 받으면 `0` 을 리턴.

## ✨ 원인
`.env`/`.env.dev` 의 Upstash 호스트 (`unique-snail-97791.upstash.io`) DNS NXDOMAIN — 인스턴스 소실. node-redis 는 `disableOfflineQueue` 기본값 false 라 명령이 무한 큐잉되어 `pfCount` 가 return 하지 않고, Express 요청이 ELB idle timeout 에 걸려 **502 Bad Gateway**.

동일 상태에서 `/api/admin/stats/members`, `/api/prompts` 등 Redis 미사용 경로는 200 정상.

## ✨ 이 PR 의 스코프
Redis **인프라 복구는 별개 작업** (Upstash 재프로비저닝 + 새 URL 을 `.env`/`.env.dev` 에 반영 + 재기동). 이 PR 은 향후 같은 장애가 재발해도 응답이 hang 되지 않도록 **코드 방어만** 담당.

`disableOfflineQueue` 를 전역으로 켜지 않은 이유: settlement (payple 캐시/락), `user-activity`, `visitor-tracking` 등 다른 caller 가 `await redisClient.get/set/del` 를 함. 갑작스런 throw 는 별도 회귀 위험 → 이번엔 신고된 엔드포인트만 국지적으로 방어.

## ✨ 검증
- `pnpm build` 통과.
- 로컬에서 실측: DNS NXDOMAIN 상태 Upstash URL 로도 `AdminVisitorStatsRepository.countUniqueOnDate/OverRange/PerDay` 가 각각 최대 2s 내에 `0` / `[]` 반환 (기존은 무한 대기).
- Redis 복구 후에는 정상 카운트 반환 (타임아웃 안 걸림).

## ✨ 기타
- 방문자 카운트는 Redis 만이 저장소. Upstash 인스턴스가 진짜 사라졌다면 데이터 리셋 — 신규 카운트부터 재누적.
- 후속 이슈 후보: settlement/user-activity 등 다른 Redis caller 도 동일한 그레이스풀 저하 필요한지 검토.

Closes #524