### PR TITLE
[FIX] Upstash 유휴 자동 삭제 방지 — /health/redis + 주간 keepalive cron (#527)

### DIFF
--- a/.github/workflows/redis-keepalive.yml
+++ b/.github/workflows/redis-keepalive.yml
@@ -1,0 +1,13 @@
+name: redis-keepalive
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'  # 매주 월요일 03:00 UTC (12:00 KST)
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping dev Redis via /health/redis
+        run: curl -fsS -m 10 https://promptplace-dev.kro.kr/health/redis

--- a/.github/workflows/redis-keepalive.yml
+++ b/.github/workflows/redis-keepalive.yml
@@ -11,3 +11,5 @@ jobs:
     steps:
       - name: Ping dev Redis via /health/redis
         run: curl -fsS -m 10 https://promptplace-dev.kro.kr/health/redis
+      - name: Ping prod Redis via /health/redis
+        run: curl -fsS -m 10 https://promptplace.kro.kr/health/redis

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { errorHandler } from "./middlewares/errorHandler";
 import { visitorTracker } from "./middlewares/visitorTracker";
 import "reflect-metadata";
 import passport from "./config/passport";
+import redisClient from "./config/redis";
 import swaggerUi from "swagger-ui-express";
 import swaggerJsdoc from "swagger-jsdoc";
 import { swaggerOptions } from "./docs/swagger/options";
@@ -210,7 +211,22 @@ app.use(errorHandler as ErrorRequestHandler);
 
 // 도커 헬스체크 라우터
 app.get('/health', (req, res) => {
-  res.status(200).send('OK');  
+  res.status(200).send('OK');
+});
+
+// ponytail: Upstash free 유휴 자동 삭제 방지용. 외부 cron 이 주기적으로 호출.
+app.get('/health/redis', async (_req, res) => {
+  try {
+    const pong = await Promise.race([
+      redisClient.ping(),
+      new Promise<string>((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), 2000),
+      ),
+    ]);
+    res.status(200).send(pong);
+  } catch {
+    res.status(503).send('REDIS_UNAVAILABLE');
+  }
 });
 
 app.use(morgan('dev')); // 사용자 요청 로그 출력


### PR DESCRIPTION
## ✨ 변경 사항
- `src/index.ts` — `/health/redis` 라우트 추가. `redisClient.ping()` 을 2s 타임아웃으로 감싸 hang 방지. 성공 200 / 실패 503.
- `.github/workflows/redis-keepalive.yml` — 매주 월 03:00 UTC (12:00 KST) 에 **dev + prod 양쪽** `/health/redis` 로 `curl -fsS`. `workflow_dispatch` 로 수동 실행도 가능.

## ✨ 원인
Upstash **free tier** 의 비활성 DB 자동 삭제 정책. Redis command 가 며칠간 없으면 삭제 대상. visitor middleware 는 `BOT_UA_PATTERN` 으로 uptime monitor / curl UA 를 걸러내서 health check 나 크롤러 트래픽이 있어도 Redis 명령으로 이어지지 않음. 실 유저 트래픽이 조용한 시기엔 Upstash 가 진짜로 비활성 → `unique-snail` 처럼 소멸.

## ✨ 왜 이 형태인가
- **외부 cron (GitHub Actions)**: 앱 재기동/배포 실패 상황에서도 마지막 방어선. 앱 내부 setInterval 은 프로세스 살아있어야만 동작.
- **인증 없음**: 정보 유출 없는 단순 ping. Secrets 관리 부담 없음. `SKIP_PATH_PREFIXES` 가 이미 `/health` prefix 를 스킵하니 방문자 카운트 오염 없음.
- **주 1회 cron**: Upstash 삭제 정책 grace 대비 안전 마진 충분. 명령 하나로 활동 인정.
- **dev + prod 둘 다**: 두 환경 모두 free tier 유지. 각 host 의 앱이 자기 REDIS_URL 로 ping.

## ✨ 검증
- `pnpm build` 통과.
- 배포 후 `curl -i https://promptplace-dev.kro.kr/health/redis` / `https://promptplace.kro.kr/health/redis` → Redis 정상이면 `200 PONG`, 죽으면 `503 REDIS_UNAVAILABLE`.
- Actions 탭 → `redis-keepalive` → `Run workflow` 로 수동 실행 즉시 검증 가능.

## ✨ 기타
- 봇 UA 는 visitor middleware 가 skip 하므로 cron 이 방문자 지표에 노이즈 남기지 않음.
- 프리티어 DB 1개 제한으로 prod/dev 가 같은 Upstash 를 공유 중 → visitor 통계/정산 락/Payple 캐시 격리 필요. 별도 이슈에서 key namespace prefix 로 해결 예정.

Closes #527