### PR TITLE
fix: prod/dev Redis 공유 격리 — 키 네임스페이스 prefix 도입 (#529)

### DIFF
--- a/src/settlements/services/settlement-payout.service.ts
+++ b/src/settlements/services/settlement-payout.service.ts
@@ -1,4 +1,5 @@
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import { SettlementPayoutRepository } from '../repositories/settlement-payout.repository';
 import { requestPayoutStandby, executePayout } from '../utils/payple-payout';
 
@@ -135,7 +136,7 @@ export const runPayoutCycle = async (): Promise<void> => {
     return;
   }
 
-  const lockAcquired = await redisClient.set(CYCLE_LOCK_KEY, '1', {
+  const lockAcquired = await redisClient.set(k(CYCLE_LOCK_KEY), '1', {
     NX: true,
     EX: CYCLE_LOCK_TTL_SECONDS,
   });
@@ -177,6 +178,6 @@ export const runPayoutCycle = async (): Promise<void> => {
   } catch (err: any) {
     console.error('[payout-cycle] cycle failed', { error: err?.message });
   } finally {
-    await redisClient.del(CYCLE_LOCK_KEY);
+    await redisClient.del(k(CYCLE_LOCK_KEY));
   }
 };

--- a/src/settlements/services/settlement-sync.service.ts
+++ b/src/settlements/services/settlement-sync.service.ts
@@ -1,5 +1,6 @@
 import prisma from '../../config/prisma';
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import {
   fetchPaypleSettlements,
   PaypleSettlementItem,
@@ -122,7 +123,7 @@ export const runSettlementSyncForDate = async (
   const maxPages = options.maxPagesPerRun ?? DEFAULT_MAX_PAGES_PER_RUN;
   const pageLimit = options.pageLimit ?? DEFAULT_PAGE_LIMIT;
   const counters = newCounters(date);
-  const lastKeyKey = `${LAST_KEY_PREFIX}:${date}`;
+  const lastKeyKey = k(`${LAST_KEY_PREFIX}:${date}`);
 
   let lastKey = (await redisClient.get(lastKeyKey)) ?? undefined;
 
@@ -200,7 +201,7 @@ export const runSettlementSyncJob = async (): Promise<void> => {
     return;
   }
 
-  const lockAcquired = await redisClient.set(SYNC_LOCK_KEY, '1', {
+  const lockAcquired = await redisClient.set(k(SYNC_LOCK_KEY), '1', {
     NX: true,
     EX: SYNC_LOCK_TTL_SECONDS,
   });
@@ -222,6 +223,6 @@ export const runSettlementSyncJob = async (): Promise<void> => {
   } catch (err: any) {
     console.error('[settlement-sync] job failed', { error: err?.message });
   } finally {
-    await redisClient.del(SYNC_LOCK_KEY);
+    await redisClient.del(k(SYNC_LOCK_KEY));
   }
 };

--- a/src/settlements/utils/payple-billing.ts
+++ b/src/settlements/utils/payple-billing.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import { AppError } from '../../errors/AppError';
 import { redactPaypleLog, buildPaypleHeaders } from './payple';
 
@@ -49,7 +50,7 @@ const getBillingAuthPath = (): string =>
 
 const fetchBillingAuth = async (work: BillingWork): Promise<BillingAuth> => {
   const { cstId, custKey } = loadCredentialsFromEnv();
-  const cacheKey = `payple:billing:auth:${work}`;
+  const cacheKey = k(`payple:billing:auth:${work}`);
 
   const cached = await redisClient.get(cacheKey);
   if (cached) {

--- a/src/settlements/utils/payple-refund.ts
+++ b/src/settlements/utils/payple-refund.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import { AppError } from '../../errors/AppError';
 import { redactPaypleLog, buildPaypleHeaders } from './payple';
 
@@ -53,7 +54,7 @@ const getRefundAuthPath = (): string =>
 const fetchRefundAuth = async (): Promise<PaypleRefundAuth> => {
   const { cstId, custKey } = loadCredentialsFromEnv();
 
-  const cached = await redisClient.get(AUTH_CACHE_KEY);
+  const cached = await redisClient.get(k(AUTH_CACHE_KEY));
   if (cached) {
     try {
       const parsed: PaypleRefundAuthCache = JSON.parse(cached);
@@ -82,7 +83,7 @@ const fetchRefundAuth = async (): Promise<PaypleRefundAuth> => {
     payHost: res.data.PCD_PAY_HOST,
     payUrl: res.data.PCD_PAY_URL,
   };
-  await redisClient.set(AUTH_CACHE_KEY, JSON.stringify(cacheable), { EX: AUTH_CACHE_TTL_SECONDS });
+  await redisClient.set(k(AUTH_CACHE_KEY), JSON.stringify(cacheable), { EX: AUTH_CACHE_TTL_SECONDS });
   return { ...cacheable, cstId, custKey };
 };
 

--- a/src/settlements/utils/payple-settlement.ts
+++ b/src/settlements/utils/payple-settlement.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import { AppError } from '../../errors/AppError';
 import { redactPaypleLog, buildPaypleHeaders } from './payple';
 
@@ -52,7 +53,7 @@ export const fetchPaypleSettlementAuth = async (): Promise<PaypleSettlementAuth>
   // 자격증명은 매 호출 env에서 (캐시 노출 영역 축소)
   const { cstId, custKey } = loadCredentialsFromEnv();
 
-  const cached = await redisClient.get(AUTH_CACHE_KEY);
+  const cached = await redisClient.get(k(AUTH_CACHE_KEY));
   if (cached) {
     try {
       const parsed: PaypleSettlementAuthCache = JSON.parse(cached);
@@ -82,7 +83,7 @@ export const fetchPaypleSettlementAuth = async (): Promise<PaypleSettlementAuth>
     payHost: res.data.PCD_PAY_HOST,
     payUrl: res.data.PCD_PAY_URL,
   };
-  await redisClient.set(AUTH_CACHE_KEY, JSON.stringify(cacheable), { EX: AUTH_CACHE_TTL_SECONDS });
+  await redisClient.set(k(AUTH_CACHE_KEY), JSON.stringify(cacheable), { EX: AUTH_CACHE_TTL_SECONDS });
   return { ...cacheable, cstId, custKey };
 };
 

--- a/src/settlements/utils/payple.ts
+++ b/src/settlements/utils/payple.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import crypto from 'crypto';
 import { AppError } from '../../errors/AppError';
 import redisClient from '../../config/redis';
+import { k as nsKey } from '../../utils/redis-key';
 import { isValidPaypleBank } from '../constants/bank';
 
 export type SellerTypeHint = 'INDIVIDUAL' | 'BUSINESS_PERSONAL' | 'BUSINESS_CORPORATE';
@@ -86,7 +87,7 @@ const getSecondsUntilMidnight = (): number => {
 };
 
 export const consumePaypleRateLimit = async (userId: number): Promise<void> => {
-  const key = `payple_limit:${userId}`;
+  const key = nsKey(`payple_limit:${userId}`);
   const ttl = getSecondsUntilMidnight();
   // NX + EX를 한 번의 atomic 호출로. 키가 없으면 0으로 초기화 + TTL.
   await redisClient.set(key, '0', { NX: true, EX: ttl });

--- a/src/settlements/utils/register-token.ts
+++ b/src/settlements/utils/register-token.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import { AppError } from '../../errors/AppError';
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import { SellerKind, BusinessKind } from '../dtos/settlement.dto';
 
 const TOKEN_TTL_SECONDS = 5 * 60;
@@ -68,7 +69,7 @@ export const consumeRegisterToken = async (token: string): Promise<RegisterToken
     throw new InvalidRegisterTokenError();
   }
 
-  const blacklistKey = `register_token_used:${payload.jti}`;
+  const blacklistKey = k(`register_token_used:${payload.jti}`);
   const setRes = await redisClient.set(blacklistKey, '1', {
     NX: true,
     EX: TOKEN_TTL_SECONDS + 60,

--- a/src/utils/redis-key.ts
+++ b/src/utils/redis-key.ts
@@ -1,0 +1,5 @@
+// prod/dev 가 같은 Upstash DB 를 공유하는 상황에서 키 충돌을 막기 위한 네임스페이스 헬퍼.
+// NODE_ENV 기준으로 자동 분리. 새 caller 는 반드시 이 k() 를 거쳐 키를 만들 것.
+const REDIS_KEY_NS = process.env.NODE_ENV === 'production' ? 'prod:' : 'dev:';
+
+export const k = (key: string): string => `${REDIS_KEY_NS}${key}`;

--- a/src/utils/user-activity.ts
+++ b/src/utils/user-activity.ts
@@ -1,11 +1,12 @@
 import redisClient from '../config/redis';
 import prisma from '../config/prisma';
+import { k } from './redis-key';
 
 const THROTTLE_SECONDS = 300;
 
 export const recordUserActivity = async (userId: number): Promise<void> => {
   try {
-    const key = `user_active:${userId}`;
+    const key = k(`user_active:${userId}`);
     const setResult = await redisClient.set(key, '1', {
       NX: true,
       EX: THROTTLE_SECONDS,

--- a/src/utils/visitor-tracking.ts
+++ b/src/utils/visitor-tracking.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto';
 import { Request } from 'express';
 import redisClient from '../config/redis';
+import { k } from './redis-key';
 
 const HLL_KEY_PREFIX = 'visitors:hll:';
 const HLL_TTL_SECONDS = 60 * 60 * 24 * 400;
@@ -13,7 +14,7 @@ export const toKstDateString = (date: Date): string =>
   new Date(date.getTime() + KST_OFFSET_MS).toISOString().slice(0, 10);
 
 export const buildHllKey = (kstDate: string): string =>
-  `${HLL_KEY_PREFIX}${kstDate}`;
+  k(`${HLL_KEY_PREFIX}${kstDate}`);
 
 export const isBotUserAgent = (ua: string | undefined): boolean => {
   if (!ua) return true;


### PR DESCRIPTION
- src/utils/redis-key.ts: NODE_ENV 기반 prod: / dev: prefix 헬퍼 k() 신설
- visitor-tracking / user-activity / register-token / payple-* / settlement-* 의 Redis 키를 모두 k() 로 감쌈
- 상수는 원본 유지, 호출 지점에서 k() 로 wrap (dotenv 로드 타이밍 안전)

## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->