### PR TITLE
[FIX] prod/dev Redis 공유 격리 — 키 네임스페이스 prefix 도입 (#529)

### DIFF
--- a/src/settlements/services/settlement-payout.service.ts
+++ b/src/settlements/services/settlement-payout.service.ts
@@ -1,4 +1,5 @@
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import { SettlementPayoutRepository } from '../repositories/settlement-payout.repository';
 import { requestPayoutStandby, executePayout } from '../utils/payple-payout';
 
@@ -135,7 +136,7 @@ export const runPayoutCycle = async (): Promise<void> => {
     return;
   }
 
-  const lockAcquired = await redisClient.set(CYCLE_LOCK_KEY, '1', {
+  const lockAcquired = await redisClient.set(k(CYCLE_LOCK_KEY), '1', {
     NX: true,
     EX: CYCLE_LOCK_TTL_SECONDS,
   });
@@ -177,6 +178,6 @@ export const runPayoutCycle = async (): Promise<void> => {
   } catch (err: any) {
     console.error('[payout-cycle] cycle failed', { error: err?.message });
   } finally {
-    await redisClient.del(CYCLE_LOCK_KEY);
+    await redisClient.del(k(CYCLE_LOCK_KEY));
   }
 };

--- a/src/settlements/services/settlement-sync.service.ts
+++ b/src/settlements/services/settlement-sync.service.ts
@@ -1,5 +1,6 @@
 import prisma from '../../config/prisma';
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import {
   fetchPaypleSettlements,
   PaypleSettlementItem,
@@ -122,7 +123,7 @@ export const runSettlementSyncForDate = async (
   const maxPages = options.maxPagesPerRun ?? DEFAULT_MAX_PAGES_PER_RUN;
   const pageLimit = options.pageLimit ?? DEFAULT_PAGE_LIMIT;
   const counters = newCounters(date);
-  const lastKeyKey = `${LAST_KEY_PREFIX}:${date}`;
+  const lastKeyKey = k(`${LAST_KEY_PREFIX}:${date}`);
 
   let lastKey = (await redisClient.get(lastKeyKey)) ?? undefined;
 
@@ -200,7 +201,7 @@ export const runSettlementSyncJob = async (): Promise<void> => {
     return;
   }
 
-  const lockAcquired = await redisClient.set(SYNC_LOCK_KEY, '1', {
+  const lockAcquired = await redisClient.set(k(SYNC_LOCK_KEY), '1', {
     NX: true,
     EX: SYNC_LOCK_TTL_SECONDS,
   });
@@ -222,6 +223,6 @@ export const runSettlementSyncJob = async (): Promise<void> => {
   } catch (err: any) {
     console.error('[settlement-sync] job failed', { error: err?.message });
   } finally {
-    await redisClient.del(SYNC_LOCK_KEY);
+    await redisClient.del(k(SYNC_LOCK_KEY));
   }
 };

--- a/src/settlements/utils/payple-billing.ts
+++ b/src/settlements/utils/payple-billing.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import { AppError } from '../../errors/AppError';
 import { redactPaypleLog, buildPaypleHeaders } from './payple';
 
@@ -49,7 +50,7 @@ const getBillingAuthPath = (): string =>
 
 const fetchBillingAuth = async (work: BillingWork): Promise<BillingAuth> => {
   const { cstId, custKey } = loadCredentialsFromEnv();
-  const cacheKey = `payple:billing:auth:${work}`;
+  const cacheKey = k(`payple:billing:auth:${work}`);
 
   const cached = await redisClient.get(cacheKey);
   if (cached) {

--- a/src/settlements/utils/payple-refund.ts
+++ b/src/settlements/utils/payple-refund.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import { AppError } from '../../errors/AppError';
 import { redactPaypleLog, buildPaypleHeaders } from './payple';
 
@@ -53,7 +54,7 @@ const getRefundAuthPath = (): string =>
 const fetchRefundAuth = async (): Promise<PaypleRefundAuth> => {
   const { cstId, custKey } = loadCredentialsFromEnv();
 
-  const cached = await redisClient.get(AUTH_CACHE_KEY);
+  const cached = await redisClient.get(k(AUTH_CACHE_KEY));
   if (cached) {
     try {
       const parsed: PaypleRefundAuthCache = JSON.parse(cached);
@@ -82,7 +83,7 @@ const fetchRefundAuth = async (): Promise<PaypleRefundAuth> => {
     payHost: res.data.PCD_PAY_HOST,
     payUrl: res.data.PCD_PAY_URL,
   };
-  await redisClient.set(AUTH_CACHE_KEY, JSON.stringify(cacheable), { EX: AUTH_CACHE_TTL_SECONDS });
+  await redisClient.set(k(AUTH_CACHE_KEY), JSON.stringify(cacheable), { EX: AUTH_CACHE_TTL_SECONDS });
   return { ...cacheable, cstId, custKey };
 };
 

--- a/src/settlements/utils/payple-settlement.ts
+++ b/src/settlements/utils/payple-settlement.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import { AppError } from '../../errors/AppError';
 import { redactPaypleLog, buildPaypleHeaders } from './payple';
 
@@ -52,7 +53,7 @@ export const fetchPaypleSettlementAuth = async (): Promise<PaypleSettlementAuth>
   // 자격증명은 매 호출 env에서 (캐시 노출 영역 축소)
   const { cstId, custKey } = loadCredentialsFromEnv();
 
-  const cached = await redisClient.get(AUTH_CACHE_KEY);
+  const cached = await redisClient.get(k(AUTH_CACHE_KEY));
   if (cached) {
     try {
       const parsed: PaypleSettlementAuthCache = JSON.parse(cached);
@@ -82,7 +83,7 @@ export const fetchPaypleSettlementAuth = async (): Promise<PaypleSettlementAuth>
     payHost: res.data.PCD_PAY_HOST,
     payUrl: res.data.PCD_PAY_URL,
   };
-  await redisClient.set(AUTH_CACHE_KEY, JSON.stringify(cacheable), { EX: AUTH_CACHE_TTL_SECONDS });
+  await redisClient.set(k(AUTH_CACHE_KEY), JSON.stringify(cacheable), { EX: AUTH_CACHE_TTL_SECONDS });
   return { ...cacheable, cstId, custKey };
 };
 

--- a/src/settlements/utils/payple.ts
+++ b/src/settlements/utils/payple.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import crypto from 'crypto';
 import { AppError } from '../../errors/AppError';
 import redisClient from '../../config/redis';
+import { k as nsKey } from '../../utils/redis-key';
 import { isValidPaypleBank } from '../constants/bank';
 
 export type SellerTypeHint = 'INDIVIDUAL' | 'BUSINESS_PERSONAL' | 'BUSINESS_CORPORATE';
@@ -86,7 +87,7 @@ const getSecondsUntilMidnight = (): number => {
 };
 
 export const consumePaypleRateLimit = async (userId: number): Promise<void> => {
-  const key = `payple_limit:${userId}`;
+  const key = nsKey(`payple_limit:${userId}`);
   const ttl = getSecondsUntilMidnight();
   // NX + EX를 한 번의 atomic 호출로. 키가 없으면 0으로 초기화 + TTL.
   await redisClient.set(key, '0', { NX: true, EX: ttl });

--- a/src/settlements/utils/register-token.ts
+++ b/src/settlements/utils/register-token.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import { AppError } from '../../errors/AppError';
 import redisClient from '../../config/redis';
+import { k } from '../../utils/redis-key';
 import { SellerKind, BusinessKind } from '../dtos/settlement.dto';
 
 const TOKEN_TTL_SECONDS = 5 * 60;
@@ -68,7 +69,7 @@ export const consumeRegisterToken = async (token: string): Promise<RegisterToken
     throw new InvalidRegisterTokenError();
   }
 
-  const blacklistKey = `register_token_used:${payload.jti}`;
+  const blacklistKey = k(`register_token_used:${payload.jti}`);
   const setRes = await redisClient.set(blacklistKey, '1', {
     NX: true,
     EX: TOKEN_TTL_SECONDS + 60,

--- a/src/utils/redis-key.ts
+++ b/src/utils/redis-key.ts
@@ -1,0 +1,5 @@
+// prod/dev 가 같은 Upstash DB 를 공유하는 상황에서 키 충돌을 막기 위한 네임스페이스 헬퍼.
+// NODE_ENV 기준으로 자동 분리. 새 caller 는 반드시 이 k() 를 거쳐 키를 만들 것.
+const REDIS_KEY_NS = process.env.NODE_ENV === 'production' ? 'prod:' : 'dev:';
+
+export const k = (key: string): string => `${REDIS_KEY_NS}${key}`;

--- a/src/utils/user-activity.ts
+++ b/src/utils/user-activity.ts
@@ -1,11 +1,12 @@
 import redisClient from '../config/redis';
 import prisma from '../config/prisma';
+import { k } from './redis-key';
 
 const THROTTLE_SECONDS = 300;
 
 export const recordUserActivity = async (userId: number): Promise<void> => {
   try {
-    const key = `user_active:${userId}`;
+    const key = k(`user_active:${userId}`);
     const setResult = await redisClient.set(key, '1', {
       NX: true,
       EX: THROTTLE_SECONDS,

--- a/src/utils/visitor-tracking.ts
+++ b/src/utils/visitor-tracking.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto';
 import { Request } from 'express';
 import redisClient from '../config/redis';
+import { k } from './redis-key';
 
 const HLL_KEY_PREFIX = 'visitors:hll:';
 const HLL_TTL_SECONDS = 60 * 60 * 24 * 400;
@@ -13,7 +14,7 @@ export const toKstDateString = (date: Date): string =>
   new Date(date.getTime() + KST_OFFSET_MS).toISOString().slice(0, 10);
 
 export const buildHllKey = (kstDate: string): string =>
-  `${HLL_KEY_PREFIX}${kstDate}`;
+  k(`${HLL_KEY_PREFIX}${kstDate}`);
 
 export const isBotUserAgent = (ua: string | undefined): boolean => {
   if (!ua) return true;


### PR DESCRIPTION
## ✨ 변경 사항
- `src/utils/redis-key.ts` 신설 — `NODE_ENV === 'production'` 이면 `prod:`, 아니면 `dev:` prefix 를 붙이는 `k(key)` 헬퍼.
- Redis 를 사용하는 모든 모듈이 키를 `k(...)` 로 감싸도록 수정. 원본 상수 (`AUTH_CACHE_KEY`, `CYCLE_LOCK_KEY`, `SYNC_LOCK_KEY` 등) 는 그대로 두고 **호출 지점에서 wrap** — 모듈 초기화 시점에 NODE_ENV 가 준비 안 됐을 리스크 회피.

수정된 caller:
- `src/utils/visitor-tracking.ts` — `buildHllKey` 결과
- `src/utils/user-activity.ts` — throttle 키
- `src/settlements/utils/register-token.ts` — blacklist 키
- `src/settlements/utils/payple.ts` — rate limit 키 (`k as nsKey` 로 alias, 지역 `[k, v]` for-loop 과 shadow 회피)
- `src/settlements/utils/payple-billing.ts` — auth cache 키
- `src/settlements/utils/payple-refund.ts` — auth cache 키
- `src/settlements/utils/payple-settlement.ts` — auth cache 키
- `src/settlements/services/settlement-payout.service.ts` — `CYCLE_LOCK_KEY`
- `src/settlements/services/settlement-sync.service.ts` — `SYNC_LOCK_KEY`, `lastKeyKey`

## ✨ 원인
Upstash 프리티어는 계정당 DB 1개 제한이라 prod (`.env`) 와 dev (`.env.dev`) 가 동일 Upstash 인스턴스를 공유. 격리 없이 공유 시 발생하는 문제:

- **방문자 통계 오염** — `visitors:hll:YYYY-MM-DD` 키가 두 환경 공용. admin 응답이 dev/prod 트래픽 합산.
- **정산 락 충돌** — `payple:payout:cycle:lock`, `payple:settlement:sync:lock` 이 서로 뺏김. cron 이 스킵됨.
- **Payple 토큰 캐시 오염** — auth cache 가 두 환경 공용. 데모/실서비스 토큰이 섞이면 결제 오동작 위험.

## ✨ 결과
같은 Upstash DB 안에서 키가 `prod:...` / `dev:...` 로 자동 분리 → 방문자 통계/정산 락/Payple 캐시 모두 논리적으로 완전 격리.

## ✨ 검증
- `pnpm build` 통과.
- `grep -rn "redisClient\." src` 로 모든 caller 가 `k(...)` 경유하는지 확인 완료 (`config/redis.ts` 자체 제외).
- `.env` / `.env.dev` / `docker-compose.yml` 모두 `NODE_ENV` 명시 → prefix 자동 유도 안정.

## ✨ 기타
- 배포 즉시 방문자 카운트는 새 prefix (`dev:visitors:hll:...` / `prod:visitors:hll:...`) 로 다시 시작. 기존 공용 키 (`visitors:hll:...`) 의 값은 조회되지 않음. HLL TTL 400일 지나면 자연 소멸.
- Payple auth 캐시도 새 prefix 로 시작 → 첫 호출에서 재발급 발생 (1회성 오버헤드, 15~25분 후 정상화).
- 정산 락 키도 새 prefix. 기존 락은 자연 만료 (30분/10분 TTL).
- 향후 유료 이전 / 계정 분리로 실제 DB 를 나눠도 prefix 유지 무해.

Closes #529